### PR TITLE
Better control on areas name

### DIFF
--- a/R/createArea.R
+++ b/R/createArea.R
@@ -1,6 +1,6 @@
 #' Create An Area In An Antares Study
 #'
-#' @param name Name of the area as a character, without space or punctuation.
+#' @param name Name of the area as a character, without space or punctuation except - and _.
 #' @param color Color of the node
 #' @param localization Localization on the map
 #' @param nodalOptimization Nodal optimization parameters
@@ -33,11 +33,16 @@ createArea <- function(name, color = grDevices::rgb(230, 108, 44, max = 255),
 
   assertthat::assert_that(class(opts) == "simOptions")
   
-  if (grepl(pattern = "(?!_)[[:punct:]]", x = name, perl = TRUE) | grepl(pattern = "[[:space:]]", x = name)) 
+  if (grepl(pattern = "(?!_)(?!-)[[:punct:]]", x = name, perl = TRUE) | grepl(pattern = "[[:space:]]", x = name)) 
     stop("Area's name must not contain space or ponctuation")
   
-  if (grepl(pattern = "[A-Z]", x = name)) 
-    stop("Area's name must be lower case")
+  # if (grepl(pattern = "[A-Z]", x = name)) 
+  #   stop("Area's name must be lower case")
+  
+  # name of the area can contain upper case in areas/list.txt (and use in graphics)
+  # (and use in graphics) but not in the folder name (and use in all other case)
+  list_name <- name
+  name <- tolower(name)
   
   if (opts$mode != "Input") 
     stop("You can initialize an area only in 'Input' mode")
@@ -53,13 +58,14 @@ createArea <- function(name, color = grDevices::rgb(230, 108, 44, max = 255),
   assertthat::assert_that(!is.null(inputPath) && file.exists(inputPath))
 
   # Update area list
-  areas <- c(opts$areaList, name)
+  areas <- readLines(file.path(inputPath, "areas/list.txt"))
+  areas <- c(areas, list_name)
   areas <- areas[!duplicated(areas)]
   areas <- paste(sort(areas), collapse = "\n")
   writeLines(text = areas, con = file.path(inputPath, "areas/list.txt"))
 
 
-
+  
   ## Create area ----
   # dir
   dir.create(path = file.path(inputPath, "areas", name), showWarnings = FALSE)

--- a/R/createArea.R
+++ b/R/createArea.R
@@ -1,6 +1,6 @@
 #' Create An Area In An Antares Study
 #'
-#' @param name Name of the area as a character, without space or punctuation except - and _.
+#' @param name Name of the area as a character, without punctuation except - and _.
 #' @param color Color of the node
 #' @param localization Localization on the map
 #' @param nodalOptimization Nodal optimization parameters
@@ -33,8 +33,8 @@ createArea <- function(name, color = grDevices::rgb(230, 108, 44, max = 255),
 
   assertthat::assert_that(class(opts) == "simOptions")
   
-  if (grepl(pattern = "(?!_)(?!-)[[:punct:]]", x = name, perl = TRUE) | grepl(pattern = "[[:space:]]", x = name)) 
-    stop("Area's name must not contain space or ponctuation")
+  if (grepl(pattern = "(?!_)(?!-)[[:punct:]]", x = name, perl = TRUE)) 
+    stop("Area's name must not ponctuation except - and _")
   
   # if (grepl(pattern = "[A-Z]", x = name)) 
   #   stop("Area's name must be lower case")

--- a/R/createLink.R
+++ b/R/createLink.R
@@ -43,6 +43,11 @@ createLink <- function(from, to, propertiesLink = propertiesLinkOptions(), dataL
   if (!is.null(dataLink)) 
     assertthat::assert_that(ncol(dataLink) == 5)
   
+  # control areas name
+  # can be with some upper case (list.txt)
+  from <- tolower(from)
+  to <- tolower(to)
+  
   # areas' order
   areas <- c(from, to)
   if (!identical(areas, sort(areas))) {

--- a/R/removeArea.R
+++ b/R/removeArea.R
@@ -16,6 +16,11 @@
 #' }
 removeArea <- function(name, opts = antaresRead::simOptions()) {
 
+  # name of the area can contain upper case in areas/list.txt (and use in graphics)
+  # (and use in graphics) but not in the folder name (and use in all other case)
+  list_name <- name
+  name <- tolower(name)
+  
   if (!name %in% opts$areaList)
     stop(paste(name, "is not a valid area"))
 
@@ -23,7 +28,9 @@ removeArea <- function(name, opts = antaresRead::simOptions()) {
   inputPath <- opts$inputPath
 
   # Update area list
-  areas <- setdiff(opts$areaList, name)
+  areas <- readLines(file.path(inputPath, "areas/list.txt"))
+  areas <- setdiff(areas, list_name)
+  areas <- areas[!duplicated(areas)]
   areas <- paste(sort(areas), collapse = "\n")
   writeLines(text = areas, con = file.path(inputPath, "areas/list.txt"))
 

--- a/R/removeLink.R
+++ b/R/removeLink.R
@@ -22,6 +22,11 @@ removeLink <- function(from, to, opts = antaresRead::simOptions()) {
   inputPath <- opts$inputPath
   assertthat::assert_that(!is.null(inputPath) && file.exists(inputPath))
   
+  # control areas name
+  # can be with some upper case (list.txt)
+  from <- tolower(from)
+  to <- tolower(to)
+  
   # areas' order
   areas <- c(from, to)
   if (!identical(areas, sort(areas))) {

--- a/man/createArea.Rd
+++ b/man/createArea.Rd
@@ -10,7 +10,7 @@ createArea(name, color = grDevices::rgb(230, 108, 44, max = 255),
   opts = antaresRead::simOptions())
 }
 \arguments{
-\item{name}{Name of the area as a character, without space or punctuation.}
+\item{name}{Name of the area as a character, without space or punctuation except - and _.}
 
 \item{color}{Color of the node}
 

--- a/man/createArea.Rd
+++ b/man/createArea.Rd
@@ -10,7 +10,7 @@ createArea(name, color = grDevices::rgb(230, 108, 44, max = 255),
   opts = antaresRead::simOptions())
 }
 \arguments{
-\item{name}{Name of the area as a character, without space or punctuation except - and _.}
+\item{name}{Name of the area as a character, without punctuation except - and _.}
 
 \item{color}{Color of the node}
 


### PR DESCRIPTION
An area can have uppercase and space in their name. This initial name is stored in the file ``areas/list.txt`` and use in some antares output. Just see the test data.

This adding control that, writing and keeping initial name in ``areas/list.txt``, else using lower case (for folder, ...). And so, adding some controls to ``links`` for enable upper/lower areas name