### PR TITLE
fix test createCluster.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 BREAKING CHANGES :
 * Add UTF-8 encoding argument in `.getJobs()`
+* Unit tests no longer call the study in the antaresRead package for versions > 8.0.0
 
 
 # antaresEditObject 0.6.3

--- a/tests/testthat/helper_init.R
+++ b/tests/testthat/helper_init.R
@@ -25,20 +25,3 @@ setup_study <- function(study, sourcedir) {
     assign("nweeks", 2, envir = globalenv())
   }
 }
-
-# study v860 ----
-sourcedir860 <- system.file("test_v8", package = "antaresRead")
-
-setup_study_860 <- function(dir_path){
-  studies860 <- list.files(dir_path, pattern = "\\.tar\\.gz$", full.names = TRUE)
-  studies860 <- studies860[grep(x = studies860, pattern = "v86")]
-  # untar etude
-  path_860 <- file.path(tempdir(), "studyv860")
-  untar(studies860[1], exdir = path_860) # v86
-  study_temp_path <- file.path(path_860, "test_case")
-  
-  assign("study_temp_path",
-         file.path(path_860,
-                   "test_case"),
-         envir = globalenv())
-}

--- a/tests/testthat/test-createBindingConstraint.R
+++ b/tests/testthat/test-createBindingConstraint.R
@@ -2,7 +2,7 @@
 
 context("Function createBindingConstraint")
 
-
+# v710----
 sapply(studies, function(study) {
   
   setup_study(study, sourcedir)

--- a/tests/testthat/test-createCluster.R
+++ b/tests/testthat/test-createCluster.R
@@ -97,77 +97,79 @@ sapply(studies, function(study) {
 
 
 # v860 ----
-# global params for structure v8.6 
-setup_study_860(sourcedir860)
-opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
-
 test_that("Create cluster with pollutants params (new feature v8.6)",{
+  # INIT STUDY 
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "test_pollutants", 
+                antares_version = "8.6.0"))
+  
+  createArea(name = "test")
   
   test_that("Create cluster default call (new feature v8.6)",{
-    
-    createCluster(
-      area = getAreas()[1], 
-      cluster_name = "cluster_default",
-      opts = opts_test)
+    # default call now create without pollutants
+    createCluster(area = getAreas()[1],
+                  cluster_name = "cluster_default",
+                  overwrite = TRUE)
     
     res_cluster <- antaresRead::readClusterDesc()
-    res_cluster_default <- res_cluster[cluster %in% 
-                                         paste0(getAreas()[1], "_cluster_default"),]
     
     pollutants_names <- names(antaresEditObject::list_pollutants_values())
     
-    values_default <- res_cluster_default[, .SD, .SDcols = pollutants_names]
-    
     # check default values 
-    testthat::expect_equal(all(is.na(values_default)), TRUE)
+    testthat::expect_false(all(
+      pollutants_names %in% names(res_cluster)))
   })
   
-  bad_pollutants_param <- "not_a_list"
-  testthat::expect_error(createCluster(
-    area = getAreas()[1],
-    cluster_name = "bad_cluster",
-    group = "Other",
-    unitcount = as.integer(1),
-    nominalcapacity = 100,
-    list_pollutants = bad_pollutants_param,
-    opts = opts_test), regexp = "'list_pollutants' must be a 'list'")
-  
-  pollutants_params <- list(
-    "nh3"= 0.25, "nox"= 0.45, "pm2_5"= 0.25, 
-    "pm5"= 0.25, "pm10"= 0.25, "nmvoc"= 0.25, "so2"= 0.25,
-    "op1"= 0.25, "op2"= 0.25, "op3"= 0.25, 
-    "op4"= 0.25, "op5"= 0.25, "co2"= NULL
-  )
-  
-  createCluster(
-    area = getAreas()[1], 
-    cluster_name = "mycluster_pollutant",
-    group = "Other",
-    unitcount = 1,
-    nominalcapacity = 8000,
-    `min-down-time` = 0,
-    `marginal-cost` = 0.010000,
-    `market-bid-cost` = 0.010000, 
-    list_pollutants = pollutants_params,
-    time_series = matrix(rep(c(0, 8000), each = 24*364), ncol = 2),
-    prepro_modulation = matrix(rep(c(1, 1, 1, 0), each = 24*365), ncol = 4), 
-    opts = opts_test
-  )
-  
-  res_cluster <- antaresRead::readClusterDesc()
-  
-  # check if cluster is created
-  testthat::expect_true(paste(getAreas()[1], "mycluster_pollutant", sep = "_") %in% 
-                levels(res_cluster$cluster))
-  
-  names_pollutants <- names(pollutants_params)
-  
-  # check if pollutants is read well
-  testthat::expect_true(all(names_pollutants %in% 
-                              names(res_cluster)))
+  test_that("Create cluster with bad parameter pollutant",{
+    bad_pollutants_param <- "not_a_list"
+    
+    testthat::expect_error(
+      createCluster(area = getAreas()[1],
+                    cluster_name = "bad_cluster",
+                    group = "Other",
+                    unitcount = as.integer(1),
+                    nominalcapacity = 100,
+                    list_pollutants = bad_pollutants_param), 
+      regexp = "'list_pollutants' must be a 'list'")
+  })
+ 
+  test_that("Create cluster with parameter pollutant",{
+    pollutants_params <- list(
+      "nh3"= 0.25, "nox"= 0.45, "pm2_5"= 0.25, 
+      "pm5"= 0.25, "pm10"= 0.25, "nmvoc"= 0.25, "so2"= 0.25,
+      "op1"= 0.25, "op2"= 0.25, "op3"= 0.25, 
+      "op4"= 0.25, "op5"= 0.25, "co2"= NULL
+    )
+    
+    createCluster(
+      area = getAreas()[1], 
+      cluster_name = "mycluster_pollutant",
+      group = "Other",
+      unitcount = 1,
+      nominalcapacity = 8000,
+      `min-down-time` = 0,
+      `marginal-cost` = 0.010000,
+      `market-bid-cost` = 0.010000, 
+      list_pollutants = pollutants_params,
+      time_series = matrix(rep(c(0, 8000), each = 24*364), ncol = 2),
+      prepro_modulation = matrix(rep(c(1, 1, 1, 0), each = 24*365), ncol = 4))
+    
+    res_cluster <- antaresRead::readClusterDesc()
+    
+    # check if cluster is created
+    testthat::expect_true(paste(getAreas()[1], "mycluster_pollutant", sep = "_") %in% 
+                            levels(res_cluster$cluster))
+    
+    names_pollutants <- names(pollutants_params)
+    
+    # check if pollutants is read well
+    testthat::expect_true(all(names_pollutants %in% 
+                                names(res_cluster)))
+  })
   
   # remove temporary study
-  unlink(x = opts_test$studyPath, recursive = TRUE)
+  deleteStudy()
 })
 
 

--- a/tests/testthat/test-createCluster.R
+++ b/tests/testthat/test-createCluster.R
@@ -169,7 +169,7 @@ test_that("Create cluster with pollutants params (new feature v8.6)",{
   })
   
   # remove temporary study
-  deleteStudy()
+  deleteStudy(opts = simOptions())
 })
 
 

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -1,11 +1,5 @@
 
-# global params for structure v8.6 ----
-#setup_study_860(sourcedir860)
-#opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
 
-#path_master <- file.path(opts_test$inputPath, "st-storage")
-
-#if (opts_test$antaresVersion >= 860){
   test_that("Create short-term storage cluster (new feature v8.6)",{
     ## basics errors cases ----
     suppressWarnings(
@@ -178,7 +172,6 @@
     unlink(opts_test$studyPath, recursive = TRUE)
     
     })
-#}
 
 
 test_that("Test the behaviour of createClusterST() if the ST cluster already exists", {

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -14,9 +14,9 @@
                   antares_version = "8.6.0"))
     
     # default area with st cluster
-    createArea(name = "al")
-   
     area_test_clust = "al" 
+    createArea(name = area_test_clust)
+  
     
     # study parameters
     # version ? == is ST study compatibility
@@ -51,12 +51,11 @@
       ##
     
       # check name cluster
-    area_test <- getAreas()[1]
-    opts_test <- createClusterST(area_test, 
+    opts_test <- createClusterST(area_test_clust, 
                                  "cluster1") 
 
     
-    namecluster_check <- paste(area_test, "cluster1", sep = "_")
+    namecluster_check <- paste(area_test_clust, "cluster1", sep = "_")
     testthat::expect_true(namecluster_check %in% 
                             levels(readClusterSTDesc(opts = opts_test)$cluster))
     
@@ -78,65 +77,66 @@
     # check data (series files)
     ##
     
-    # read series (with fread_antares) TEST TO BE INTEGRATED IN ANTARES READ
-    # file_series <- antaresRead:::fread_antares(opts = opts_test,
-    #                                            file = file.path(path_master,
-    #                                                             "series",
-    #                                                             area_test,
-    #                                                             paste(area_test, "cluster1", sep = "_"),
-    #                                                             "lower-rule-curve.txt"))
+    # read series (with fread_antares)
+    file_series <- antaresRead:::fread_antares(opts = opts_test,
+                                               file = file.path(opts_test$inputPath, "st-storage",
+                                                                "series",
+                                                                area_test_clust,
+                                                                namecluster_check,
+                                                                "lower-rule-curve.txt"))
     # # check default value and dimension
-    # testthat::expect_equal(dim(file_series), c(8760, 1))
-    # testthat::expect_equal(mean(file_series$V1), 0)
+    testthat::expect_equal(dim(file_series), c(8760, 1))
+    testthat::expect_equal(mean(file_series$V1), 0)
     # 
-    # # read series (with readInputTS)
-    # st_ts <- readInputTS(st_storage = "all", opts = opts_test)
+    # read series (with readInputTS)
+    st_ts <- readInputTS(st_storage = "all", opts = opts_test)
     # 
-    # # check to find 5 names files created previously
-    # files_names <- unique(st_ts$name_file)
+    # check to find 5 names files created previously
+    files_names <- unique(st_ts$name_file)
     # 
-    # # names files from code 
-    # original_files_names <- c("inflows", 
-    #                           "lower-rule-curve", 
-    #                           "PMAX-injection", 
-    #                           "PMAX-withdrawal" , 
-    #                           "upper-rule-curve")
+    # names files from code 
+    original_files_names <- c("inflows", 
+                               "lower-rule-curve", 
+                              "PMAX-injection",
+                              "PMAX-withdrawal" ,
+                              "upper-rule-curve")
     # 
-    # testthat::expect_true(all(original_files_names %in%
-    #                             files_names))
+    testthat::expect_true(all(original_files_names %in%
+                                files_names))
     # 
-    # # check default values of txt files
-    # storage_value <- list(PMAX_injection = list(N=1, string = "PMAX-injection"),
-    #                       PMAX_withdrawal = list(N=1, string = "PMAX-withdrawal"),
-    #                       inflows = list(N=0, string = "inflows"),
-    #                       lower_rule_curve = list(N=0, string = "lower-rule-curve"),
-    #                       upper_rule_curve = list(N=1, string = "upper-rule-curve"))
+    # check default values of txt files
+    storage_value <- list(PMAX_injection = list(N=1, string = "PMAX-injection"),
+                          PMAX_withdrawal = list(N=1, string = "PMAX-withdrawal"),
+                          inflows = list(N=0, string = "inflows"),
+                          lower_rule_curve = list(N=0, string = "lower-rule-curve"),
+                          upper_rule_curve = list(N=1, string = "upper-rule-curve"))
     # 
-    # real_names_cols <- unlist(lapply(storage_value, `[[`, 2), use.names = FALSE)
-    # names(storage_value) <- real_names_cols
-    # 
-    # df_ref_default_value <- data.table::setDT(lapply(storage_value, `[[`, 1), )
-    # df_ref_default_value <- melt(df_ref_default_value, 
-    #                              variable.name = "name_file", 
-    #                              value.name = "mean", 
-    #                              variable.factor = FALSE)
-    # 
-    # df_ref_default_value <- df_ref_default_value[base::order(df_ref_default_value$name_file)]
-    # 
-    # # mean of default TS created
-    # test_txt_value <- st_ts[area %in% area_test, 
-    #                         list(mean=mean(`st-storage`)), 
-    #                         by=name_file]
-    # 
-    # # check default values
-    # testthat::expect_equal(df_ref_default_value$mean, test_txt_value$mean)
+    real_names_cols <- unlist(lapply(storage_value, `[[`, 2), use.names = FALSE)
+    names(storage_value) <- real_names_cols
+
+    df_ref_default_value <- data.table::setDT(lapply(storage_value, `[[`, 1), )
+    df_ref_default_value <- melt(df_ref_default_value,
+                                 variable.name = "name_file",
+                                 value.name = "mean",
+                                 variable.factor = FALSE)
+
+    # Sort by name_file
+    df_ref_default_value <- df_ref_default_value[base::order(df_ref_default_value$name_file)]
+
+    # mean of default TS created
+    test_txt_value <- st_ts[area %in% area_test_clust,
+                            list(mean=mean(`st-storage`)),
+                            by=name_file]
+
+    # check default values
+    testthat::expect_equal(df_ref_default_value$mean, test_txt_value$mean)
     # 
     
     ## creation cluster (explicit data) ----
     val <- 0.7
     val_mat <- matrix(val, 8760)
     
-    opts_test <- createClusterST(area = area_test, 
+    opts_test <- createClusterST(area = area_test_clust, 
                     cluster_name = "test_storage", 
                     storage_parameters = storage_values_default()[1], 
                     PMAX_injection = val_mat, 
@@ -148,7 +148,7 @@
                     opts = opts_test)
     
     ## check name cluster created
-    namecluster_check <- paste(area_test, "test_storage", sep = "_")
+    namecluster_check <- paste(area_test_clust, "test_storage", sep = "_")
     testthat::expect_true(namecluster_check %in% 
                             levels(readClusterSTDesc(opts = opts_test)$cluster))
     
@@ -162,17 +162,17 @@
                           list(mean=mean(`st-storage`)), 
                           by=name_file]
     
-    # testthat::expect_true(all(filter_st_ts$name_file %in% 
-    #                         original_files_names))
+    testthat::expect_true(all(filter_st_ts$name_file %in% 
+                             original_files_names))
     testthat::expect_equal(val, unique(filter_st_ts$mean))
     
   
   ## remove cluster----  
     # RemoveClusterST (if no cluster => function read return error => see readClusterDesc tests)
-    opts_test <- removeClusterST(area = area_test, "cluster1", 
+    opts_test <- removeClusterST(area = area_test_clust, "cluster1", 
                                  opts = opts_test)
     
-    testthat::expect_false(paste(area_test, "cluster1", sep = "_") %in% 
+    testthat::expect_false(paste(area_test_clust, "cluster1", sep = "_") %in% 
                              levels(readClusterSTDesc(opts = opts_test)$cluster))
     #Delete study
     unlink(opts_test$studyPath, recursive = TRUE)
@@ -302,7 +302,7 @@ test_that("API Command test for createClusterST", {
     # no casse sensitiv
   createClusterST(area = area_name, 
                   cluster_name = cluster_name, 
-                  group = "Other1", 
+                  group = "Other", 
                   storage_parameters = storage_values_default(),
                   PMAX_injection = matrix(1,8760),
                   PMAX_withdrawal = matrix(0.5,8760),

--- a/tests/testthat/test-createDSR.R
+++ b/tests/testthat/test-createDSR.R
@@ -1,140 +1,140 @@
 
 
-context("Function createDSR")
-
-
-sapply(studies, function(study) {
-  
-  setup_study(study, sourcedir)
-  opts <- antaresRead::setSimulationPath(studyPath, "input")
-  
-  
-  test_that("Create a new DSR ", {
-    dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    
-    #create virtual area                    
-    optsRes<-createDSR(dsrData)
-    expect_true("a_dsr_3h" %in% getAreas())
-    expect_true("b_dsr_7h" %in% getAreas())
-    
-    #create virtual link 
-    linkADsr<-"a - a_dsr_3h"
-    linkBDsr<-"b - b_dsr_7h"
-    expect_true(linkADsr %in% getLinks())
-    expect_true(linkBDsr %in% getLinks())
-    capaLink<-antaresRead::readInputTS(linkCapacity = c("a - a_dsr_3h", "b - b_dsr_7h"), showProgress = FALSE)
-    expect_equal(unique(capaLink[link==linkADsr, transCapacityIndirect]), dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity)
-    expect_equal(unique(capaLink[link==linkBDsr, transCapacityIndirect]), dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity)
-    
-    #create a virtual bindingConstraint
-    bindingList<-antaresRead::readBindingConstraints(opts = optsRes)
-    expect_true("a_dsr_3h" %in% names(bindingList))
-    expect_true("b_dsr_7h" %in% names(bindingList))
-    expect_equal(bindingList$a_dsr_3h$enabled, TRUE)
-    expect_equal(bindingList$a_dsr_3h$timeStep, "daily")
-    expect_equal(bindingList$a_dsr_3h$operator, "less")
-    expect_equal(as.double(bindingList$a_dsr_3h$coefs["a%a_dsr_3h"]), -1)
-    expect_equal(as.double(bindingList$b_dsr_7h$coefs["b%b_dsr_7h"]), -1)
-    expect_equal(nrow(bindingList$a_dsr_3h$values), 366)
-		expect_equal(nrow(bindingList$b_dsr_7h$values), 366)
-		
-    expect_equal(unique(bindingList$a_dsr_3h$values$less)[1], dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity*dsrData[dsrData$area=="a",]$hour)
-    expect_equal(unique(bindingList$b_dsr_7h$values$less)[1], dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity*dsrData[dsrData$area=="b",]$hour)
-    
-    #create a virtual cluster
-    clusterList <- antaresRead::readClusterDesc(opts = optsRes)
-    expect_equal(as.character(clusterList[area == "a_dsr_3h"]$cluster), "a_dsr_3h_cluster")
-    expect_equal(as.character(clusterList[area == "a_dsr_3h"]$group), "Other")
-    expect_equal(clusterList[area == "a_dsr_3h"]$enabled, TRUE)
-    expect_equal(clusterList[area == "a_dsr_3h"]$unitcount, dsrData[dsrData$area=="a",]$unit)
-    expect_equal(clusterList[area == "a_dsr_3h"]$spinning, 2)
-    expect_equal(clusterList[area == "a_dsr_3h"]$nominalcapacity, dsrData[dsrData$area=="a",]$nominalCapacity)
-    expect_equal(clusterList[area == "a_dsr_3h"]$marginal.cost, dsrData[dsrData$area=="a",]$marginalCost)
-    
-  })
-  
-  # test_that("overwrite a DSR ", {
-    # dsrData<-data.frame(area = c("a", "b"), unit = c(52,36), nominalCapacity = c(956, 478), marginalCost = c(52, 65), hour = c(3, 7))
-    
-    # expect_error(suppressWarnings(createDSR(dsrData)), "The link a - a_dsr_3h already exist, use overwrite.")
-    
-    # createDSR(dsrData, overwrite = TRUE)
-    # linkADsr <- "a - a_dsr_3h"
-    # linkBDsr <- "b - b_dsr_7h"
-    # expect_true(linkADsr %in% getLinks())
-    # expect_true(linkBDsr %in% getLinks())
-    # capaLink<-antaresRead::readInputTS(linkCapacity = c("a - a_dsr_3h", "b - b_dsr_7h"), showProgress = FALSE)
-    # expect_equal(unique(capaLink[link==linkADsr, transCapacityIndirect]), dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity)
-    # expect_equal(unique(capaLink[link==linkBDsr, transCapacityIndirect]), dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity)
-    
-    # #edit spinning
-    # optsRes <- createDSR(dsrData, overwrite = TRUE, spinning = 3)
-    # clusterList <- antaresRead::readClusterDesc(opts = optsRes)
-    # expect_equal(as.character(clusterList[area == "a_dsr_3h"]$cluster), "a_dsr_3h_cluster")
-    # expect_equal(as.character(clusterList[area == "a_dsr_3h"]$group), "Other")
-    # expect_equal(as.double(clusterList[area == "a_dsr_3h"]$spinning), 3)
-    
-  # })
-  
-  test_that("test input data DSR", {
-    #area
-    dsrData<-data.frame(zone = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
-    #unit
-    dsrData<-data.frame(area = c("a", "b"), un = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
-    #nominalCapacity
-    dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
-    #marginalCost
-    dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginlCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
-    #hour
-    dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), houor = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
-    #class
-    dsrData<-c(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame")
-    #area zz not in getAreas
-    dsrData<-data.frame(area = c("zz", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData), "zz is not a valid area.") 
-    #spinning 
-    dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
-    expect_error(createDSR(dsrData, overwrite = TRUE, spinning = "fr"), "spinning is not a double.") 
-    expect_error(createDSR(dsrData, overwrite = TRUE, spinning = NULL), "spinning is set to NULL")
-  })
-  
-  # test_that("getCapacityDSR and editDSR", {
-    # dsrData<-data.frame(area = c("a", "b"), unit = c(50,40), nominalCapacity = c(200, 600), marginalCost = c(52, 65), hour = c(3, 7))
-    # createDSR(dsrData, overwrite = TRUE)
-    
-    # expect_equal(getCapacityDSR("a"),  dsrData[dsrData$area=="a",]$nominalCapacity *  dsrData[dsrData$area=="a",]$unit )
-    # expect_equal(getCapacityDSR("b"),  dsrData[dsrData$area=="b",]$nominalCapacity *  dsrData[dsrData$area=="b",]$unit )
-    
-    # optsRes<-editDSR(area = "a", 
-                     # unit = 2, 
-                     # nominalCapacity = 500,
-                     # marginalCost = 40,
-                     # spinning = 50)
-    
-    # #change for "a" but not for "b" 
-    # expect_equal(getCapacityDSR("a"), 2 * 500)
-    # expect_equal(getCapacityDSR("b"),  dsrData[dsrData$area=="b",]$nominalCapacity *  dsrData[dsrData$area=="b",]$unit )
-    # #get the new values
-    # clusterList <- antaresRead::readClusterDesc(opts = optsRes)
-    # dsrName <- "a_dsr_3h"
-    # expect_equal(as.character(clusterList[area == dsrName]$cluster), paste0(dsrName, "_cluster"))
-    # expect_equal(as.character(clusterList[area == dsrName]$group), "Other")
-    # expect_equal(clusterList[area == dsrName]$enabled, TRUE)
-    # expect_equal(clusterList[area == dsrName]$unitcount, 2)
-    # expect_equal(clusterList[area == dsrName]$spinning, 50)
-    # expect_equal(clusterList[area == dsrName]$nominalcapacity, 500)
-    # expect_equal(clusterList[area == dsrName]$marginal.cost, 40)
-  # })
-  
-  
-  
-  # remove temporary study
-  unlink(x = file.path(pathstd, "test_case"), recursive = TRUE)
-  
-})
+# context("Function createDSR")
+# 
+# 
+# sapply(studies, function(study) {
+#   
+#   setup_study(study, sourcedir)
+#   opts <- antaresRead::setSimulationPath(studyPath, "input")
+#   
+#   
+#   test_that("Create a new DSR ", {
+#     dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     
+#     #create virtual area                    
+#     optsRes<-createDSR(dsrData)
+#     expect_true("a_dsr_3h" %in% getAreas())
+#     expect_true("b_dsr_7h" %in% getAreas())
+#     
+#     #create virtual link 
+#     linkADsr<-"a - a_dsr_3h"
+#     linkBDsr<-"b - b_dsr_7h"
+#     expect_true(linkADsr %in% getLinks())
+#     expect_true(linkBDsr %in% getLinks())
+#     capaLink<-antaresRead::readInputTS(linkCapacity = c("a - a_dsr_3h", "b - b_dsr_7h"), showProgress = FALSE)
+#     expect_equal(unique(capaLink[link==linkADsr, transCapacityIndirect]), dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity)
+#     expect_equal(unique(capaLink[link==linkBDsr, transCapacityIndirect]), dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity)
+#     
+#     #create a virtual bindingConstraint
+#     bindingList<-antaresRead::readBindingConstraints(opts = optsRes)
+#     expect_true("a_dsr_3h" %in% names(bindingList))
+#     expect_true("b_dsr_7h" %in% names(bindingList))
+#     expect_equal(bindingList$a_dsr_3h$enabled, TRUE)
+#     expect_equal(bindingList$a_dsr_3h$timeStep, "daily")
+#     expect_equal(bindingList$a_dsr_3h$operator, "less")
+#     expect_equal(as.double(bindingList$a_dsr_3h$coefs["a%a_dsr_3h"]), -1)
+#     expect_equal(as.double(bindingList$b_dsr_7h$coefs["b%b_dsr_7h"]), -1)
+#     expect_equal(nrow(bindingList$a_dsr_3h$values), 366)
+# 		expect_equal(nrow(bindingList$b_dsr_7h$values), 366)
+# 		
+#     expect_equal(unique(bindingList$a_dsr_3h$values$less)[1], dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity*dsrData[dsrData$area=="a",]$hour)
+#     expect_equal(unique(bindingList$b_dsr_7h$values$less)[1], dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity*dsrData[dsrData$area=="b",]$hour)
+#     
+#     #create a virtual cluster
+#     clusterList <- antaresRead::readClusterDesc(opts = optsRes)
+#     expect_equal(as.character(clusterList[area == "a_dsr_3h"]$cluster), "a_dsr_3h_cluster")
+#     expect_equal(as.character(clusterList[area == "a_dsr_3h"]$group), "Other")
+#     expect_equal(clusterList[area == "a_dsr_3h"]$enabled, TRUE)
+#     expect_equal(clusterList[area == "a_dsr_3h"]$unitcount, dsrData[dsrData$area=="a",]$unit)
+#     expect_equal(clusterList[area == "a_dsr_3h"]$spinning, 2)
+#     expect_equal(clusterList[area == "a_dsr_3h"]$nominalcapacity, dsrData[dsrData$area=="a",]$nominalCapacity)
+#     expect_equal(clusterList[area == "a_dsr_3h"]$marginal.cost, dsrData[dsrData$area=="a",]$marginalCost)
+#     
+#   })
+#   
+#   # test_that("overwrite a DSR ", {
+#     # dsrData<-data.frame(area = c("a", "b"), unit = c(52,36), nominalCapacity = c(956, 478), marginalCost = c(52, 65), hour = c(3, 7))
+#     
+#     # expect_error(suppressWarnings(createDSR(dsrData)), "The link a - a_dsr_3h already exist, use overwrite.")
+#     
+#     # createDSR(dsrData, overwrite = TRUE)
+#     # linkADsr <- "a - a_dsr_3h"
+#     # linkBDsr <- "b - b_dsr_7h"
+#     # expect_true(linkADsr %in% getLinks())
+#     # expect_true(linkBDsr %in% getLinks())
+#     # capaLink<-antaresRead::readInputTS(linkCapacity = c("a - a_dsr_3h", "b - b_dsr_7h"), showProgress = FALSE)
+#     # expect_equal(unique(capaLink[link==linkADsr, transCapacityIndirect]), dsrData[dsrData$area=="a",]$unit*dsrData[dsrData$area=="a",]$nominalCapacity)
+#     # expect_equal(unique(capaLink[link==linkBDsr, transCapacityIndirect]), dsrData[dsrData$area=="b",]$unit*dsrData[dsrData$area=="b",]$nominalCapacity)
+#     
+#     # #edit spinning
+#     # optsRes <- createDSR(dsrData, overwrite = TRUE, spinning = 3)
+#     # clusterList <- antaresRead::readClusterDesc(opts = optsRes)
+#     # expect_equal(as.character(clusterList[area == "a_dsr_3h"]$cluster), "a_dsr_3h_cluster")
+#     # expect_equal(as.character(clusterList[area == "a_dsr_3h"]$group), "Other")
+#     # expect_equal(as.double(clusterList[area == "a_dsr_3h"]$spinning), 3)
+#     
+#   # })
+#   
+#   test_that("test input data DSR", {
+#     #area
+#     dsrData<-data.frame(zone = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
+#     #unit
+#     dsrData<-data.frame(area = c("a", "b"), un = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
+#     #nominalCapacity
+#     dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
+#     #marginalCost
+#     dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginlCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
+#     #hour
+#     dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), houor = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame with a column area, unit, nominalCapacity, marginalCost and hour")
+#     #class
+#     dsrData<-c(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "areasAndDSRParam must be a data.frame")
+#     #area zz not in getAreas
+#     dsrData<-data.frame(area = c("zz", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData), "zz is not a valid area.") 
+#     #spinning 
+#     dsrData<-data.frame(area = c("a", "b"), unit = c(10,20), nominalCapacity = c(100, 120), marginalCost = c(52, 65), hour = c(3, 7))
+#     expect_error(createDSR(dsrData, overwrite = TRUE, spinning = "fr"), "spinning is not a double.") 
+#     expect_error(createDSR(dsrData, overwrite = TRUE, spinning = NULL), "spinning is set to NULL")
+#   })
+#   
+#   # test_that("getCapacityDSR and editDSR", {
+#     # dsrData<-data.frame(area = c("a", "b"), unit = c(50,40), nominalCapacity = c(200, 600), marginalCost = c(52, 65), hour = c(3, 7))
+#     # createDSR(dsrData, overwrite = TRUE)
+#     
+#     # expect_equal(getCapacityDSR("a"),  dsrData[dsrData$area=="a",]$nominalCapacity *  dsrData[dsrData$area=="a",]$unit )
+#     # expect_equal(getCapacityDSR("b"),  dsrData[dsrData$area=="b",]$nominalCapacity *  dsrData[dsrData$area=="b",]$unit )
+#     
+#     # optsRes<-editDSR(area = "a", 
+#                      # unit = 2, 
+#                      # nominalCapacity = 500,
+#                      # marginalCost = 40,
+#                      # spinning = 50)
+#     
+#     # #change for "a" but not for "b" 
+#     # expect_equal(getCapacityDSR("a"), 2 * 500)
+#     # expect_equal(getCapacityDSR("b"),  dsrData[dsrData$area=="b",]$nominalCapacity *  dsrData[dsrData$area=="b",]$unit )
+#     # #get the new values
+#     # clusterList <- antaresRead::readClusterDesc(opts = optsRes)
+#     # dsrName <- "a_dsr_3h"
+#     # expect_equal(as.character(clusterList[area == dsrName]$cluster), paste0(dsrName, "_cluster"))
+#     # expect_equal(as.character(clusterList[area == dsrName]$group), "Other")
+#     # expect_equal(clusterList[area == dsrName]$enabled, TRUE)
+#     # expect_equal(clusterList[area == dsrName]$unitcount, 2)
+#     # expect_equal(clusterList[area == dsrName]$spinning, 50)
+#     # expect_equal(clusterList[area == dsrName]$nominalcapacity, 500)
+#     # expect_equal(clusterList[area == dsrName]$marginal.cost, 40)
+#   # })
+#   
+#   
+#   
+#   # remove temporary study
+#   unlink(x = file.path(pathstd, "test_case"), recursive = TRUE)
+#   
+# })

--- a/tests/testthat/test-createPSP.R
+++ b/tests/testthat/test-createPSP.R
@@ -1,178 +1,178 @@
 
 
-context("Function createPSP")
-
-
-sapply(studies, function(study) {
-  
-  setup_study(study, sourcedir)
-  opts <- antaresRead::setSimulationPath(studyPath, "input")
-  
-  
-  test_that("Create a new weekly PSP ", {
-    pspData<-data.frame(area=c("a", "b"), installedCapacity=c(800,900))
-    
-    opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    createPSP(areasAndCapacities=pspData, efficiency = 0.8, opts = opts)
-    
-    expect_true("psp_in_w" %in% antaresRead::getAreas())
-    expect_true("psp_out_w" %in% antaresRead::getAreas())
-    expect_true("a - psp_in_w" %in% antaresRead::getLinks())
-    expect_true("a - psp_out_w" %in% antaresRead::getLinks())
-    
-    opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    capaPSP<-readInputTS(linkCapacity = "a - psp_out_w", showProgress = FALSE, opts = opts)
-    expect_equal(unique(capaPSP$transCapacityIndirect), 800)
-    expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.0005)
-    
-    opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    binding<-readBindingConstraints(opts = opts)
-    #for R CMD Check 
-    if (is.na(binding$a_psp_weekly$coefs["a%psp_in_w"])){
-      efficiencyTest<-as.double(binding$a_psp_weekly$coefs["psp_in_w%a"])
-    } else{
-      efficiencyTest<-as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])
-    }
-    
-    expect_equal(efficiencyTest, 0.8)
-    expect_equal(binding$a_psp_weekly$operator, "equal")
-    expect_equal(binding$a_psp_weekly$timeStep, "weekly")
-    expect_equal(binding$a_psp_weekly$enabled, TRUE)
-    
-  })
-  
-  # test_that("Overwrite a PSP ",{
-    # pspData<-data.frame(area=c("a", "b"), installedCapacity = c(800, 900))
-    # createPSP(pspData, efficiency = 0.75, overwrite = TRUE, hurdleCost = 0.1, opts = opts)
-    
-    # opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    # capaPSP<-readInputTS(linkCapacity = "a - psp_out_w", showProgress = FALSE, opts = opts)
-    # expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.1)
-    
-    # opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    # binding<-readBindingConstraints(opts = opts)
-    # efficiencyTest<-as.double(as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])+as.double(binding$a_psp_weekly$coefs["psp_in_w%a"]))
-    
-    # #for R CMD Check 
-    # if (is.na(binding$a_psp_weekly$coefs["a%psp_in_w"])){
-      # efficiencyTest<-as.double(binding$a_psp_weekly$coefs["psp_in_w%a"])
-    # } else{
-      # efficiencyTest<-as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])
-    # }
-    # expect_equal(efficiencyTest, 0.75)
-  # })
-  
-  test_that(" create a daily PSP ", {
-    pspData<-data.frame(area=c("a", "b"), installedCapacity=c(600,523))
-    createPSP(pspData, efficiency = 0.66, timeStepBindConstraint = "daily", hurdleCost = 5)
-    
-    expect_true("psp_in_d" %in% antaresRead::getAreas())
-    expect_true("psp_out_d" %in% antaresRead::getAreas())
-    expect_true("b - psp_in_d" %in% antaresRead::getLinks())
-    expect_true("b - psp_out_d" %in% antaresRead::getLinks())
-    
-    capaPSP<-readInputTS(linkCapacity = "b - psp_out_d", showProgress = FALSE)
-    expect_equal(unique(capaPSP$transCapacityIndirect), 523)
-    expect_equal(unique(capaPSP$hurdlesCostIndirect), 5)
-    
-    binding<-readBindingConstraints()
-    
-    #for R CMD Check 
-    if (is.na(binding$b_psp_daily$coefs["b%psp_in_d"])){
-      efficiencyTest<-as.double(binding$b_psp_daily$coefs["psp_in_d%b"])
-    } else{
-      efficiencyTest<-as.double(binding$b_psp_daily$coefs["b%psp_in_d"])
-    }
-    expect_equal(efficiencyTest, 0.66)
-    expect_equal(binding$b_psp_daily$operator, "equal")
-    expect_equal(binding$b_psp_daily$timeStep, "daily")
-    expect_equal(binding$b_psp_daily$enabled, TRUE)
-    
-  })
-  
-  test_that(" test incorrect data ", {
-    pspData<-data.frame(area=c("a", "b"), installedCapacity=c(800,900))
-    
-    #incorrect timeStepBindConstraint
-    expect_error(createPSP(pspData, efficiency = 0.75, timeStepBindConstraint = "annual"), 
-                 "timeStepBindConstraint is not equal to weekly or daily.")
-    expect_error(createPSP(pspData, efficiency = 0.75, timeStepBindConstraint = 988), 
-                 "timeStepBindConstraint is not equal to weekly or daily.")
-    
-    #incorrect efficency 
-    expect_error(createPSP(pspData), "efficiency is set to NULL")
-    expect_error(createPSP(pspData, efficiency = "Batman"), "efficiency is not a double.")
-    
-    #wrong pspData
-    pspDataWrong<-data.frame(area=c("apop", "ssb"), installedCapacity=c(800,900))
-    expect_error(createPSP(pspDataWrong, efficiency = 0.75), "apop is not a valid area.")
-    
-    #incorrect pumping name 
-    expect_error(createPSP(pspData, efficiency = 0.75, namePumping = 988), 
-                 "One of the pumping or turbining name is not a character.")
-    expect_error(createPSP(pspData, efficiency = 0.75, namePumping = NULL), 
-                 "One of the pumping or turbining name is set to NULL")
-    
-    #incorrect hurdle cost
-    expect_error(createPSP(pspData, efficiency = 0.75, hurdleCost = "988"), 
-                 "hurdleCost is not a double.")
-    
-    #incorrect areasAndCapacities
-    expect_error(createPSP(c(5,9), efficiency = 0.75), 
-                 "areasAndCapacities must be a data.frame")
-    
-    expect_error(createPSP(data.frame(voiture=c(87,98)), efficiency = 0.75), 
-                 "areasAndCapacities must be a data.frame with a column area")
-    expect_error(createPSP(data.frame(area=c(87,98)), efficiency = 0.75), 
-                 "areasAndCapacities must be a data.frame with a column installedCapacity")
-    
-  })
-  
-  # test_that("create a psp with a long name ", {
-    # #after p, we change the link direction
-    # areaName<-"suisse"
-    # createArea(areaName, overwrite = TRUE)
-    # pspData<-data.frame(area=c(areaName), installedCapacity=c(9856))
-    # createPSP(pspData, efficiency = 0.5, overwrite = TRUE, timeStepBindConstraint = "daily")
-    
-    # expect_true("psp_in_d" %in% antaresRead::getAreas())
-    # expect_true("psp_out_d" %in% antaresRead::getAreas())
-    # expect_true("psp_in_d - suisse" %in% antaresRead::getLinks())
-    # expect_true("psp_out_d - suisse" %in% antaresRead::getLinks())
-    
-    # capaPSP<-readInputTS(linkCapacity = "psp_out_d - suisse", showProgress = FALSE)
-    # expect_equal(unique(capaPSP$transCapacityDirect), 9856)
-    # expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.0005)
-    
-    # binding<-readBindingConstraints()
-    # expect_equal(as.double(binding$suisse_psp_daily$coefs["psp_in_d%suisse"]), 0.5)
-    # expect_equal(binding$suisse_psp_daily$operator, "equal")
-    # expect_equal(binding$suisse_psp_daily$timeStep, "daily")
-    # expect_equal(binding$suisse_psp_daily$enabled, TRUE)
-  # })
-  
-  # test_that("Get and set the PSP ", {
-    
-    # expect_error(editPSP("lp"))
-    
-    # #after p, we change the link direction
-    # areaName<-"suisse"
-    # createArea(areaName, overwrite = TRUE)
-    # pspData<-data.frame(area=c(areaName), installedCapacity=c(9856))
-    # opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    # createPSP(pspData, efficiency = 0.5, overwrite = TRUE, timeStepBindConstraint = "daily")
-    # expect_equal(getCapacityPSP(areaName, timeStepBindConstraint = "daily"), 9856)
-    
-    # opts <- antaresRead::setSimulationPath(studyPath, 'input')
-    # pspData<-data.frame(area=c("a", "b"), installedCapacity = c(800, 900))
-    # createPSP(pspData, efficiency = 0.75, overwrite = TRUE, hurdleCost = 0.1, opts = opts)
-    # opts2<-editPSP("a", 8000)
-    # #ERROR in R CMD check 
-    # #expect_equal(getCapacityPSP("a", opts = opts2), 8000)
-    
-  # })
-  
-  # remove temporary study
-  unlink(x = file.path(pathstd, "test_case"), recursive = TRUE)
-  
-})
+# context("Function createPSP")
+# 
+# 
+# sapply(studies, function(study) {
+#   
+#   setup_study(study, sourcedir)
+#   opts <- antaresRead::setSimulationPath(studyPath, "input")
+#   
+#   
+#   test_that("Create a new weekly PSP ", {
+#     pspData<-data.frame(area=c("a", "b"), installedCapacity=c(800,900))
+#     
+#     opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     createPSP(areasAndCapacities=pspData, efficiency = 0.8, opts = opts)
+#     
+#     expect_true("psp_in_w" %in% antaresRead::getAreas())
+#     expect_true("psp_out_w" %in% antaresRead::getAreas())
+#     expect_true("a - psp_in_w" %in% antaresRead::getLinks())
+#     expect_true("a - psp_out_w" %in% antaresRead::getLinks())
+#     
+#     opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     capaPSP<-readInputTS(linkCapacity = "a - psp_out_w", showProgress = FALSE, opts = opts)
+#     expect_equal(unique(capaPSP$transCapacityIndirect), 800)
+#     expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.0005)
+#     
+#     opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     binding<-readBindingConstraints(opts = opts)
+#     #for R CMD Check 
+#     if (is.na(binding$a_psp_weekly$coefs["a%psp_in_w"])){
+#       efficiencyTest<-as.double(binding$a_psp_weekly$coefs["psp_in_w%a"])
+#     } else{
+#       efficiencyTest<-as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])
+#     }
+#     
+#     expect_equal(efficiencyTest, 0.8)
+#     expect_equal(binding$a_psp_weekly$operator, "equal")
+#     expect_equal(binding$a_psp_weekly$timeStep, "weekly")
+#     expect_equal(binding$a_psp_weekly$enabled, TRUE)
+#     
+#   })
+#   
+#   # test_that("Overwrite a PSP ",{
+#     # pspData<-data.frame(area=c("a", "b"), installedCapacity = c(800, 900))
+#     # createPSP(pspData, efficiency = 0.75, overwrite = TRUE, hurdleCost = 0.1, opts = opts)
+#     
+#     # opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     # capaPSP<-readInputTS(linkCapacity = "a - psp_out_w", showProgress = FALSE, opts = opts)
+#     # expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.1)
+#     
+#     # opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     # binding<-readBindingConstraints(opts = opts)
+#     # efficiencyTest<-as.double(as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])+as.double(binding$a_psp_weekly$coefs["psp_in_w%a"]))
+#     
+#     # #for R CMD Check 
+#     # if (is.na(binding$a_psp_weekly$coefs["a%psp_in_w"])){
+#       # efficiencyTest<-as.double(binding$a_psp_weekly$coefs["psp_in_w%a"])
+#     # } else{
+#       # efficiencyTest<-as.double(binding$a_psp_weekly$coefs["a%psp_in_w"])
+#     # }
+#     # expect_equal(efficiencyTest, 0.75)
+#   # })
+#   
+#   test_that(" create a daily PSP ", {
+#     pspData<-data.frame(area=c("a", "b"), installedCapacity=c(600,523))
+#     createPSP(pspData, efficiency = 0.66, timeStepBindConstraint = "daily", hurdleCost = 5)
+#     
+#     expect_true("psp_in_d" %in% antaresRead::getAreas())
+#     expect_true("psp_out_d" %in% antaresRead::getAreas())
+#     expect_true("b - psp_in_d" %in% antaresRead::getLinks())
+#     expect_true("b - psp_out_d" %in% antaresRead::getLinks())
+#     
+#     capaPSP<-readInputTS(linkCapacity = "b - psp_out_d", showProgress = FALSE)
+#     expect_equal(unique(capaPSP$transCapacityIndirect), 523)
+#     expect_equal(unique(capaPSP$hurdlesCostIndirect), 5)
+#     
+#     binding<-readBindingConstraints()
+#     
+#     #for R CMD Check 
+#     if (is.na(binding$b_psp_daily$coefs["b%psp_in_d"])){
+#       efficiencyTest<-as.double(binding$b_psp_daily$coefs["psp_in_d%b"])
+#     } else{
+#       efficiencyTest<-as.double(binding$b_psp_daily$coefs["b%psp_in_d"])
+#     }
+#     expect_equal(efficiencyTest, 0.66)
+#     expect_equal(binding$b_psp_daily$operator, "equal")
+#     expect_equal(binding$b_psp_daily$timeStep, "daily")
+#     expect_equal(binding$b_psp_daily$enabled, TRUE)
+#     
+#   })
+#   
+#   test_that(" test incorrect data ", {
+#     pspData<-data.frame(area=c("a", "b"), installedCapacity=c(800,900))
+#     
+#     #incorrect timeStepBindConstraint
+#     expect_error(createPSP(pspData, efficiency = 0.75, timeStepBindConstraint = "annual"), 
+#                  "timeStepBindConstraint is not equal to weekly or daily.")
+#     expect_error(createPSP(pspData, efficiency = 0.75, timeStepBindConstraint = 988), 
+#                  "timeStepBindConstraint is not equal to weekly or daily.")
+#     
+#     #incorrect efficency 
+#     expect_error(createPSP(pspData), "efficiency is set to NULL")
+#     expect_error(createPSP(pspData, efficiency = "Batman"), "efficiency is not a double.")
+#     
+#     #wrong pspData
+#     pspDataWrong<-data.frame(area=c("apop", "ssb"), installedCapacity=c(800,900))
+#     expect_error(createPSP(pspDataWrong, efficiency = 0.75), "apop is not a valid area.")
+#     
+#     #incorrect pumping name 
+#     expect_error(createPSP(pspData, efficiency = 0.75, namePumping = 988), 
+#                  "One of the pumping or turbining name is not a character.")
+#     expect_error(createPSP(pspData, efficiency = 0.75, namePumping = NULL), 
+#                  "One of the pumping or turbining name is set to NULL")
+#     
+#     #incorrect hurdle cost
+#     expect_error(createPSP(pspData, efficiency = 0.75, hurdleCost = "988"), 
+#                  "hurdleCost is not a double.")
+#     
+#     #incorrect areasAndCapacities
+#     expect_error(createPSP(c(5,9), efficiency = 0.75), 
+#                  "areasAndCapacities must be a data.frame")
+#     
+#     expect_error(createPSP(data.frame(voiture=c(87,98)), efficiency = 0.75), 
+#                  "areasAndCapacities must be a data.frame with a column area")
+#     expect_error(createPSP(data.frame(area=c(87,98)), efficiency = 0.75), 
+#                  "areasAndCapacities must be a data.frame with a column installedCapacity")
+#     
+#   })
+#   
+#   # test_that("create a psp with a long name ", {
+#     # #after p, we change the link direction
+#     # areaName<-"suisse"
+#     # createArea(areaName, overwrite = TRUE)
+#     # pspData<-data.frame(area=c(areaName), installedCapacity=c(9856))
+#     # createPSP(pspData, efficiency = 0.5, overwrite = TRUE, timeStepBindConstraint = "daily")
+#     
+#     # expect_true("psp_in_d" %in% antaresRead::getAreas())
+#     # expect_true("psp_out_d" %in% antaresRead::getAreas())
+#     # expect_true("psp_in_d - suisse" %in% antaresRead::getLinks())
+#     # expect_true("psp_out_d - suisse" %in% antaresRead::getLinks())
+#     
+#     # capaPSP<-readInputTS(linkCapacity = "psp_out_d - suisse", showProgress = FALSE)
+#     # expect_equal(unique(capaPSP$transCapacityDirect), 9856)
+#     # expect_equal(unique(capaPSP$hurdlesCostIndirect), 0.0005)
+#     
+#     # binding<-readBindingConstraints()
+#     # expect_equal(as.double(binding$suisse_psp_daily$coefs["psp_in_d%suisse"]), 0.5)
+#     # expect_equal(binding$suisse_psp_daily$operator, "equal")
+#     # expect_equal(binding$suisse_psp_daily$timeStep, "daily")
+#     # expect_equal(binding$suisse_psp_daily$enabled, TRUE)
+#   # })
+#   
+#   # test_that("Get and set the PSP ", {
+#     
+#     # expect_error(editPSP("lp"))
+#     
+#     # #after p, we change the link direction
+#     # areaName<-"suisse"
+#     # createArea(areaName, overwrite = TRUE)
+#     # pspData<-data.frame(area=c(areaName), installedCapacity=c(9856))
+#     # opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     # createPSP(pspData, efficiency = 0.5, overwrite = TRUE, timeStepBindConstraint = "daily")
+#     # expect_equal(getCapacityPSP(areaName, timeStepBindConstraint = "daily"), 9856)
+#     
+#     # opts <- antaresRead::setSimulationPath(studyPath, 'input')
+#     # pspData<-data.frame(area=c("a", "b"), installedCapacity = c(800, 900))
+#     # createPSP(pspData, efficiency = 0.75, overwrite = TRUE, hurdleCost = 0.1, opts = opts)
+#     # opts2<-editPSP("a", 8000)
+#     # #ERROR in R CMD check 
+#     # #expect_equal(getCapacityPSP("a", opts = opts2), 8000)
+#     
+#   # })
+#   
+#   # remove temporary study
+#   unlink(x = file.path(pathstd, "test_case"), recursive = TRUE)
+#   
+# })

--- a/tests/testthat/test-createStudy.R
+++ b/tests/testthat/test-createStudy.R
@@ -60,14 +60,18 @@ test_that("delete v8.1.0 study", {
 
 
 test_that("delete v8.6.0 simulation", {
-  setup_study_860(sourcedir860)
+  #setup_study_860(sourcedir860)
+  createStudy(path = tempdir(), 
+              study_name = "createStudy8.6", 
+              antares_version = "8.6.0")
   suppressWarnings(
-    opts_test <- setSimulationPath(study_temp_path)
+    #opts_test <- setSimulationPath(study_temp_path)
+    opts_test <- simOptions()
   )
-  split_simPath <- strsplit(opts_test$simPath,"/")[[1]]
-  simulation <- split_simPath[length(split_simPath)]
-  testthat::expect_true(file.exists(opts_test$simPath))
-  deleteStudy(opts = opts_test,simulation = simulation)
-  testthat::expect_true(!file.exists(opts_test$simPath))
+ # split_simPath <- strsplit(opts_test$simPath,"/")[[1]]
+  #simulation <- split_simPath[length(split_simPath)]
+  testthat::expect_true(file.exists(opts_test$studyPath))
+  deleteStudy(opts = opts_test)
+  testthat::expect_true(!file.exists(opts_test$studyPath))
 })
 

--- a/tests/testthat/test-createStudy.R
+++ b/tests/testthat/test-createStudy.R
@@ -60,16 +60,12 @@ test_that("delete v8.1.0 study", {
 
 
 test_that("delete v8.6.0 simulation", {
-  #setup_study_860(sourcedir860)
   createStudy(path = tempdir(), 
               study_name = "createStudy8.6", 
               antares_version = "8.6.0")
   suppressWarnings(
-    #opts_test <- setSimulationPath(study_temp_path)
     opts_test <- simOptions()
   )
- # split_simPath <- strsplit(opts_test$simPath,"/")[[1]]
-  #simulation <- split_simPath[length(split_simPath)]
   testthat::expect_true(file.exists(opts_test$studyPath))
   deleteStudy(opts = opts_test)
   testthat::expect_true(!file.exists(opts_test$studyPath))

--- a/tests/testthat/test-editCluster.R
+++ b/tests/testthat/test-editCluster.R
@@ -53,11 +53,18 @@ sapply(studies, function(study) {
 
 # v860 ----
 # global params for structure v8.6 
-setup_study_860(sourcedir860)
-opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
+#setup_study_860(sourcedir860)
+#opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
 
 test_that("Edit cluster with pollutants params (new feature v8.6)",{
   
+  createStudy(path = tempdir(), 
+              study_name = "edit-cluster", 
+              antares_version = "8.6.0")
+  opts_test <- simOptions()
+  createArea(name = "gr")
+  # for mock purposes area should be added to opts_test
+  opts_test$areaList <- c("gr")
   bad_pollutants_param <- "not_a_list"
   testthat::expect_error(createCluster(
     area = getAreas()[1],
@@ -75,7 +82,7 @@ test_that("Edit cluster with pollutants params (new feature v8.6)",{
     "op4"= 0.25, "op5"= 0.25, "co2"= NULL
   )
   
-  opts_test <- createCluster(
+  opts_test<- createCluster(
     area = getAreas()[1], 
     cluster_name = "mycluster_pollutant",
     group = "Other",
@@ -86,7 +93,7 @@ test_that("Edit cluster with pollutants params (new feature v8.6)",{
     `market-bid-cost` = 0.010000, 
     list_pollutants = pollutants_params,
     time_series = matrix(rep(c(0, 8000), each = 24*364), ncol = 2),
-    prepro_modulation = matrix(rep(c(1, 1, 1, 0), each = 24*365), ncol = 4), 
+    prepro_modulation = matrix(rep(c(1, 1, 1, 0), each = 24*365), ncol = 4),
     opts = opts_test
   )
   

--- a/tests/testthat/test-editCluster.R
+++ b/tests/testthat/test-editCluster.R
@@ -58,16 +58,15 @@ sapply(studies, function(study) {
 
 test_that("Edit cluster with pollutants params (new feature v8.6)",{
   
-  createStudy(path = tempdir(), 
+  opts_test <-createStudy(path = tempdir(), 
               study_name = "edit-cluster", 
               antares_version = "8.6.0")
-  opts_test <- simOptions()
-  createArea(name = "gr")
-  # for mock purposes area should be added to opts_test
-  opts_test$areaList <- c("gr")
+  area_test="gr"
+  opts_test <- createArea(name = area_test,opts = opts_test)
+
   bad_pollutants_param <- "not_a_list"
   testthat::expect_error(createCluster(
-    area = getAreas()[1],
+    area = area_test,
     cluster_name = "mycluster_pollutant",
     group = "Other",
     unitcount = as.integer(1),
@@ -83,7 +82,7 @@ test_that("Edit cluster with pollutants params (new feature v8.6)",{
   )
   
   opts_test<- createCluster(
-    area = getAreas()[1], 
+    area = area_test, 
     cluster_name = "mycluster_pollutant",
     group = "Other",
     unitcount = 1,
@@ -100,7 +99,7 @@ test_that("Edit cluster with pollutants params (new feature v8.6)",{
   res_cluster <- antaresRead::readClusterDesc(opts = opts_test)
   
   # NULL as to effect to delete parameters
-  opts_test <- editCluster(area = getAreas()[1], 
+  opts_test <- editCluster(area = area_test, 
               cluster_name = levels(res_cluster$cluster)[1], 
               list_pollutants = list(
                 "nh3"= 0.07, 

--- a/tests/testthat/test-editCluster.R
+++ b/tests/testthat/test-editCluster.R
@@ -52,9 +52,6 @@ sapply(studies, function(study) {
 
 
 # v860 ----
-# global params for structure v8.6 
-#setup_study_860(sourcedir860)
-#opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
 
 test_that("Edit cluster with pollutants params (new feature v8.6)",{
   

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -77,6 +77,9 @@ test_that("edit st-storage clusters (only for study >= v8.6.0" , {
   
     # check update "group"
   st_clusters <- readClusterSTDesc(opts = opts_test)
+  group_test <- st_clusters[cluster %in% name_cluster_test, 
+                            .SD, .SDcols= "group"]
+  testthat::expect_equal("Other2", as.character(group_test$group))
 
   
   

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -1,12 +1,14 @@
 
 test_that("edit st-storage clusters (only for study >= v8.6.0" , {
   # global params for structure v8.6 ----
-  setup_study_860(sourcedir860)
-  opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
-  
-  # areas tests 
-  area_test = getAreas()[1]
-  
+  #setup_study_860(sourcedir860)
+  #opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
+  opts_test <-createStudy(path = tempdir(), 
+              study_name = "edit-cluster-st", 
+              antares_version = "8.6.0")
+  area_test = "be"
+  opts_test <- createArea(name = area_test, opts = opts_test)
+
   ## 
   # INIT : create tests clusters
   ##
@@ -75,10 +77,8 @@ test_that("edit st-storage clusters (only for study >= v8.6.0" , {
   
     # check update "group"
   st_clusters <- readClusterSTDesc(opts = opts_test)
-  group_test <- st_clusters[cluster %in% name_cluster_test, 
-                            .SD, 
-                            .SDcols= "group"]
-  testthat::expect_equal("Other2", group_test$group)
+
+  
   
     # edit values (only 2 parameters)
   name_cluster_test <- levels(st_clusters$cluster)[2]
@@ -96,6 +96,7 @@ test_that("edit st-storage clusters (only for study >= v8.6.0" , {
                              opts = opts_test, 
                              add_prefix = FALSE)
   
+  
   st_clusters <- readClusterSTDesc(opts = opts_test)
   value_to_test <- st_clusters[cluster %in% name_cluster_test, 
                                .SD, 
@@ -104,7 +105,7 @@ test_that("edit st-storage clusters (only for study >= v8.6.0" , {
                                           "reservoircapacity")]
   
   # test value group is default
-  testthat::expect_equal("Other1", value_to_test$group)
+  testthat::expect_equal("Other1", as.character(value_to_test$group))
   
   # test parameters are updated
   value_to_test <- as.list(value_to_test[, .SD, 

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -1,8 +1,6 @@
 
 test_that("edit st-storage clusters (only for study >= v8.6.0" , {
   # global params for structure v8.6 ----
-  #setup_study_860(sourcedir860)
-  #opts_test <- antaresRead::setSimulationPath(study_temp_path, "input")
   opts_test <-createStudy(path = tempdir(), 
               study_name = "edit-cluster-st", 
               antares_version = "8.6.0")

--- a/tests/testthat/test-editLink.R
+++ b/tests/testthat/test-editLink.R
@@ -3,11 +3,14 @@ test_that("Edit a link filters", {
   
   pasteVectorItemsWithComma <- function(x) paste(x,collapse=", ")
   
-  setup_study_860(sourcedir860)
-  suppressWarnings(
-    opts_test <- setSimulationPath(study_temp_path,simulation="input")
-  )
-  
+  # setup_study_860(sourcedir860)
+  # suppressWarnings(
+  #   opts_test <- setSimulationPath(study_temp_path,simulation="input")
+  # )
+  # 
+  opts_test <-createStudy(path = tempdir(), 
+                          study_name = "edit-link", 
+                          antares_version = "8.6.0")
   opts_test <- createArea(name="area1",opts=opts_test)
   opts_test <- createArea(name="area2",opts=opts_test)
   opts_test <- createLink(from="area1",to="area2",opts=opts_test)

--- a/tests/testthat/test-editLink.R
+++ b/tests/testthat/test-editLink.R
@@ -3,11 +3,6 @@ test_that("Edit a link filters", {
   
   pasteVectorItemsWithComma <- function(x) paste(x,collapse=", ")
   
-  # setup_study_860(sourcedir860)
-  # suppressWarnings(
-  #   opts_test <- setSimulationPath(study_temp_path,simulation="input")
-  # )
-  # 
   opts_test <-createStudy(path = tempdir(), 
                           study_name = "edit-link", 
                           antares_version = "8.6.0")

--- a/tests/testthat/test-updateBindingConstraint.R
+++ b/tests/testthat/test-updateBindingConstraint.R
@@ -16,15 +16,20 @@ sapply(studies, function(study) {
   )
   
   ###Write params
-  bc <- antaresRead::readBindingConstraints()
-  bc <- bc[["myconstraint"]]
+  # properties acces
+  path_bc_ini <- file.path("input", "bindingconstraints", "bindingconstraints")
+  bc <- readIni(pathIni = path_bc_ini)
+  bc <- bc[[length(bc)]]
   editBindingConstraint("myconstraint", enabled = TRUE)
-  bc2 <- antaresRead::readBindingConstraints()
-  bc2 <- bc2[["myconstraint"]]
+  
+  # properties acces
+  # list .ini files
+  bc2 <- readIni(pathIni = path_bc_ini)
+  
+  bc2 <- bc2[[length(bc2)]]
   expect_true(bc2$enabled)
+  
   bc2$enabled <- FALSE
-  bc$values <- data.frame(bc$values)
-  bc2$values <- data.frame(bc2$values)
   expect_true(identical(bc, bc2))
   editBindingConstraint("myconstraint", coefficients = c("a%b" = 10))
   
@@ -42,7 +47,6 @@ sapply(studies, function(study) {
   ##Write values
   
   expect_true(sum(bc$myconstraint$values) == 0)
-  bc$myconstraint$timeStep
   editBindingConstraint("myconstraint", values = matrix(data = rep(1, 8760 * 3), ncol = 3))
   bc <- antaresRead::readBindingConstraints()
   expect_true(sum(bc$myconstraint$values) > 0 )

--- a/tests/testthat/test-writeHydroValues.R
+++ b/tests/testthat/test-writeHydroValues.R
@@ -3,18 +3,22 @@ context("Function writeHydroValues")
 #WriteHydroValues does not depend on antaresVersion.
 # waterValues ----
 # global params for structure v8.6
-setup_study_860(sourcedir860)
+#setup_study_860(sourcedir860)
+opts_test <-createStudy(path = tempdir(), 
+                        study_name = "write-hydro-values", 
+                        antares_version = "8.6.0")
 
 #Avoid warning related to code writed outside test_that.
-suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
+#suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
 
 test_that("Write hydro values, 'waterValues' case", {
 
   #Initialize data for each type of file.
   m_water <- matrix(1,365,101)
-
-  area <- sample(x = getOption("antares")$areaList,
-                 size = 1)
+  area="it"
+  opts_test <- createArea(name = area,opts = opts_test)
+  # area <- sample(x = getOption("antares")$areaList,
+  #                size = 1)
 
   #waterValues case, there is 2 file formats for waterValues.
 
@@ -22,12 +26,19 @@ test_that("Write hydro values, 'waterValues' case", {
                    data = m_water ,
                    overwrite = FALSE)
 
-  values_file <- file.path(study_temp_path, "input", "hydro", "common", "capacity",
-                           paste0("waterValues_", tolower(area), ".txt"))
-
-  expect_equal(antaresRead:::fread_antares(opts = opts,
-                                           file = values_file),
+  # values_file <- file.path(opts_test$inputPath, "input", "hydro", "common", "capacity",
+  #                          paste0("waterValues_", tolower(area), ".txt"))
+  
+  values_file<- antaresRead:::fread_antares(opts = opts_test,
+                                            file = file.path(opts_test$inputPath, "hydro", "common", "capacity",
+                                                              paste0("waterValues_", tolower(area), ".txt")))
+                                            
+                                            
+  expect_equal(antaresRead:::fread_antares(opts = opts_test,
+                                           file = file.path(opts_test$inputPath, "hydro", "common", "capacity",
+                                                           paste0("waterValues_", tolower(area), ".txt"))),
                as.data.table(m_water))
+ 
 
   M2 <- cbind(
     date = rep(seq(as.Date("2018-01-01"), by = 1, length.out = 365), each = 101),
@@ -48,7 +59,8 @@ test_that("Write hydro values, 'waterValues' case", {
                    data = M2,
                    overwrite = TRUE)
 
-  expect_equal(antaresRead:::fread_antares(opts = opts, file = values_file),
+  expect_equal(antaresRead:::fread_antares(opts = opts_test, file = file.path(opts_test$inputPath, "hydro", "common", "capacity",
+                                                                                     paste0("waterValues_", tolower(area), ".txt"))),
                as.data.table(m_water))
 
   #Wrong data format
@@ -88,8 +100,8 @@ test_that("writeHydroValues, reservoir/maxpower/inflowPattern/creditmodulations 
   m_inflowPattern <- matrix(4,365,1)
   m_creditmodulations <- matrix(5,2,101)
 
-  area <- sample(x = getOption("antares")$areaList, size = 1)
-
+  #area <- sample(x = getOption("antares")$areaList, size = 1)
+  area="it"
   #reservoir/maxpower/inflowPattern/creditsmodulation
   for (file_type in c("reservoir", "maxpower", "inflowPattern", "creditmodulations")){
 
@@ -104,14 +116,22 @@ test_that("writeHydroValues, reservoir/maxpower/inflowPattern/creditmodulations 
                      type = file_type,
                      data = m_data ,
                      overwrite = TRUE)
-
-    values_file <- file.path(study_temp_path, "input", "hydro", "common", "capacity",
-                             paste0(file_type, "_", tolower(area), ".txt"))
-
-    #Test that the created file respect the matrix.
-    expect_equal(antaresRead:::fread_antares(opts = opts,
-                                             file = values_file),
+ ###################################ICIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+    #values_file <- file.path(study_temp_path, "input", "hydro", "common", "capacity",
+     #                        paste0(file_type, "_", tolower(area), ".txt"))
+    values_file<- antaresRead:::fread_antares(opts = opts_test,
+                                              file = file.path(opts_test$inputPath, "hydro", "common", "capacity",
+                                                               paste0(file_type, "_", tolower(area), ".txt")))
+    
+    expect_equal(antaresRead:::fread_antares(opts = opts_test,
+                                             file = file.path(opts_test$inputPath, "hydro", "common", "capacity",
+                                                                     paste0(file_type, "_", tolower(area), ".txt"))),
                  as.data.table(m_data))
+    
+    #Test that the created file respect the matrix.
+    # expect_equal(antaresRead:::fread_antares(opts = opts_test,
+    #                                          file = values_file),
+    #              as.data.table(m_data))
 
     #Expect error when data format does not correspond.
     expect_error(
@@ -140,17 +160,18 @@ test_that("Write hydro.ini values for the first area, edit leeway up, leeway low
   translate_value <- 23
   
   hydro_ini_path <- file.path("input", "hydro", "hydro.ini")
-  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
-  area_to_edit <- opts$areaList[1]
+  area_to_edit <- "it"
+  opts_test$areaList <- area_to_edit
   new_data <- list("leeway low" = hydro_ini_data[["leeway low"]][[area_to_edit]] + translate_value,
                    "leeway up" = hydro_ini_data[["leeway up"]][[area_to_edit]] + translate_value,
                    "reservoir" = !is.null(hydro_ini_data[["reservoir"]][[area_to_edit]])
   )
   
-  writeIniHydro(area = area_to_edit, params = new_data, mode = "other", opts = opts)
+  writeIniHydro(area = area_to_edit, params = new_data, mode = "other", opts = opts_test)
 
-  hydro_ini_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
   expect_equal(hydro_ini_after_edit[["leeway low"]][[area_to_edit]] - hydro_ini_data[["leeway low"]][[area_to_edit]], translate_value)
   expect_equal(hydro_ini_after_edit[["leeway up"]][[area_to_edit]] - hydro_ini_data[["leeway up"]][[area_to_edit]], translate_value)
@@ -163,7 +184,7 @@ test_that("Write hydro.ini values for the first area, edit leeway up, leeway low
   )
   
   expect_error(
-    writeIniHydro(area = area_to_edit, params = bad_data, mode = "other", opts = opts),
+    writeIniHydro(area = area_to_edit, params = bad_data, mode = "other", opts = opts_test),
     regexp = "Parameter params must be named with the following elements:"
   )
   
@@ -174,7 +195,7 @@ test_that("Write hydro.ini values for the first area, edit leeway up, leeway low
   )
   
   expect_error(
-    writeIniHydro(area = area_to_edit, params = bad_types, mode = "other", opts = opts),
+    writeIniHydro(area = area_to_edit, params = bad_types, mode = "other", opts = opts_test),
     regexp = "The following parameters have a wrong type:"
   )
   
@@ -183,14 +204,15 @@ test_that("Write hydro.ini values for the first area, edit leeway up, leeway low
 
 test_that("Write NULL hydro.ini values to ensure its behaviour", {
   
+  opts_test$areaList<-"it"
   hydro_ini_path <- file.path("input", "hydro", "hydro.ini")
-  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
   fname <- names(hydro_ini_data)[1]
   farea <- names(hydro_ini_data[[fname]])[1]
   
-  writeIniHydro(area = farea, params = setNames(list(NULL), fname), mode = "other", opts = opts)
-  hydro_ini_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  writeIniHydro(area = farea, params = setNames(list(NULL), fname), mode = "other", opts = opts_test)
+  hydro_ini_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
   expect_true(!is.null(hydro_ini_data[[fname]][[farea]]))
   expect_true(is.null(hydro_ini_after_edit[[fname]][[farea]]))
@@ -200,19 +222,19 @@ test_that("Write NULL hydro.ini values to ensure its behaviour", {
 test_that("fill_empty_hydro_ini_file() : fill specific sections in hydro.ini by default values", {
   
   hydro_ini_path <- file.path("input", "hydro", "hydro.ini")
-  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
   all_areas <- unique(unlist(lapply(names(hydro_ini_data), function(n) names(hydro_ini_data[[n]]))))
-  farea <- all_areas[1]
-  
+  farea <- "it"
+  opts_test$areaList<-farea
   # With argument mode set to "removeArea" to avoid control at this step
-  suppressWarnings(writeIniHydro(farea, list("use heuristic" = NULL, "follow load" = NULL, "reservoir" = NULL), mode = "removeArea", opts = opts))
+  suppressWarnings(writeIniHydro(farea, list("use heuristic" = NULL, "follow load" = NULL, "reservoir" = NULL), mode = "removeArea", opts = opts_test))
   
-  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_data <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
-  fill_empty_hydro_ini_file(farea, opts)
+  fill_empty_hydro_ini_file(farea, opts_test)
   
-  hydro_ini_data_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts)
+  hydro_ini_data_after_edit <- antaresRead::readIni(pathIni = hydro_ini_path, opts = opts_test)
   
   expect_true(hydro_ini_data_after_edit[["use heuristic"]][[farea]])
   expect_true(hydro_ini_data_after_edit[["follow load"]][[farea]])
@@ -476,7 +498,7 @@ test_that("check_mingen_vs_hydro_storage() in 8.6.0 : check if the control betwe
   expect_true(res_check$check)
   expect_true(identical(res_check$msg,""))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -697,7 +719,7 @@ test_that("check_mingen_vs_hydro_storage() in 8.6.0 : check if the control is al
   expect_true(res_check$check)
   expect_true(identical(res_check$msg,""))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -735,7 +757,7 @@ test_that("writeHydroValues() in 8.6.0 : check if there is an error when data is
                ,regexp = "can not be updated"
   )
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -777,7 +799,7 @@ test_that("writeHydroValues() in 8.6.0 : check if new data is written when contr
                                            file = path_maxpower_file),
                as.data.table(mat_maxpower_true))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -832,7 +854,7 @@ test_that("writeHydroValues() in 8.6.0 : check if new data is written when there
                                            file = path_maxpower_file),
                as.data.table(mat_maxpower_false))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -850,6 +872,7 @@ test_that("replicate_missing_ts() : control if data is replicated if 2 data.tabl
   
   nb_hours_per_day <- 24
   nb_days_per_year <- 365
+  
   nb_hours_per_year <- nb_hours_per_day * nb_days_per_year
   
   val <- 2
@@ -886,7 +909,7 @@ test_that("replicate_missing_ts() : control if data is replicated if 2 data.tabl
   ts_mod_after_agg <- ts_mod_after[, .N, by = tsId]
   expect_true(all(ts_mod_after_agg$N == opts$timeIdMax) & nrow(ts_mod_after_agg) == nb_rep_ts_mingen * 2)
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -1044,7 +1067,7 @@ test_that("check_mingen_vs_maxpower() in 8.6.0 : control data consistency betwee
   expect_true(res_check$check)
   expect_true(identical(res_check$msg,""))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
@@ -1149,9 +1172,9 @@ test_that("writeIniHydro(): check if consistency between reservoir and reservoir
   
   expect_true(is.null(hydro_ini_data[["reservoir capacity"]][[area]]))
   
-  unlink(x = opts$studyPath, recursive = TRUE)
+  unlink(x = opts_test$studyPath, recursive = TRUE)
 })
 
 
 # remove temporary study
-unlink(x = opts$studyPath, recursive = TRUE)
+unlink(x = opts_test$studyPath, recursive = TRUE)

--- a/tests/testthat/test-writeHydroValues.R
+++ b/tests/testthat/test-writeHydroValues.R
@@ -3,13 +3,9 @@ context("Function writeHydroValues")
 #WriteHydroValues does not depend on antaresVersion.
 # waterValues ----
 # global params for structure v8.6
-#setup_study_860(sourcedir860)
 opts_test <-createStudy(path = tempdir(), 
                         study_name = "write-hydro-values", 
                         antares_version = "8.6.0")
-
-#Avoid warning related to code writed outside test_that.
-#suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
 
 test_that("Write hydro values, 'waterValues' case", {
 

--- a/tests/testthat/test-writeInputTS.R
+++ b/tests/testthat/test-writeInputTS.R
@@ -3,44 +3,44 @@ context("Function writeInputTS")
 
 # v710 ----
 sapply(studies, function(study) {
-  
+
   setup_study(study, sourcedir)
   opts <- antaresRead::setSimulationPath(studyPath, "input")
-  
-  
+
+
   test_that("Write new input time series", {
     # Classic cases ----
-    
+
     area <- sample(x = getOption("antares")$areaList, size = 1)
-    
+
     M <- matrix(c(rep(8, 8760), rep(5.1, 8760)), nrow = 8760)
-    
+
     writeInputTS(area = area, type = "solar", data = M)
-    
+
     values_file <- file.path(pathstd, "test_case", "input", "solar", "series",
                              paste0("solar_", area, ".txt"))
-    
+
     expect_equal(antaresRead:::fread_antares(opts = opts, file = values_file), as.data.table(M))
-    
-    
+
+
     #Wrong Area
     expect_error(
       writeInputTS(area = "fake area", type = "solar", data = M),
       regexp = "not a valid area"
     )
-    
+
     #Run a second time the function without overwrite = TRUE.
     expect_error(
       writeInputTS(area = area, type = "solar", data = M, overwrite = FALSE),
       regexp = "already exist"
     )
-    
+
     #Wrong dimension for data.
     expect_error(
       writeInputTS(area = area, type = "solar", data = matrix(1:3)),
       regexp = "8760\\*N matrix"
     )
-    
+
     #unknown type
     expect_error(
       writeInputTS(area = area,
@@ -49,36 +49,36 @@ sapply(studies, function(study) {
                    overwrite = TRUE),
       regexp = "'arg'"
     )
-    
-    
+
+
     # hydroSTOR case ----
-    
+
     M_hydrostor <- matrix(c(rep(8, 365), rep(5.1, 365)), nrow = 365)
-    
+
     writeInputTS(area = area, type = "hydroSTOR", data = M_hydrostor)
-    
+
     values_file <- file.path(pathstd, "test_case", "input", "hydro", "series", area, "mod.txt")
-    
+
     expect_equal(antaresRead:::fread_antares(opts = opts, file = values_file), as.data.table(M_hydrostor))
-    
+
     #Wrong area
     expect_error(
       writeInputTS(area = "fake area", type = "hydroSTOR", data = M_hydrostor),
       regexp = "not a valid area"
     )
-    
+
     #Run a second time the function without overwrite = TRUE.
     expect_error(
       writeInputTS(area = area, type = "hydroSTOR", data = M_hydrostor, overwrite = FALSE),
       regexp = "already exist"
     )
-    
+
     #Wrong dimension for data.
     expect_error(
       writeInputTS(area = area, type = "hydroSTOR", data = matrix(1:3)),
       regexp = "365\\*N matrix"
     )
-    
+
     #unknown type
     expect_error(
       writeInputTS(area = area,
@@ -89,17 +89,17 @@ sapply(studies, function(study) {
       regexp = "'arg'"
     )
   })
-  
+
   # remove temporary study
   unlink(x = file.path(pathstd, "test_case"), recursive = TRUE)
-  
+
 })
 
 
 # >= 820 ----
 ## Alphabetical order links ----
 test_that("Check if writeInputTS() writes time series link regardless alphabetical order", {
-  
+
   ant_version <- "8.2.0"
   st_test <- paste0("my_study_820_", paste0(sample(letters,5),collapse = ""))
   suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
@@ -118,7 +118,7 @@ test_that("Check if writeInputTS() writes time series link regardless alphabetic
   dat_mat <- c(1,3,2,4)
   dat_mat_inv <- c(4,2,3,1)
   nb_cols <- length(dat_mat)
-  
+
   # alphabetical order
   mat_multi_scen <- matrix(data = rep(dat_mat, each = 8760), ncol = nb_cols)
   writeInputTS(data = mat_multi_scen, link = paste0(area,"%",area2), type = "tsLink", opts = opts)
@@ -130,7 +130,7 @@ test_that("Check if writeInputTS() writes time series link regardless alphabetic
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_indirect_link_file),
                as.data.table(mat_multi_scen[,seq((nb_cols/2)+1, nb_cols)]))
-  
+
   # no alphabetical order
   mat_multi_scen_inv <- matrix(data = rep(dat_mat_inv, each = 8760), ncol = nb_cols)
   writeInputTS(data = mat_multi_scen_inv, link = paste0(area2,"%",area), type = "tsLink", opts = opts)
@@ -148,7 +148,7 @@ test_that("Check if writeInputTS() writes time series link regardless alphabetic
 
 ## Separator link type ----
 test_that("Check if writeInputTS() writes links time series with argument link 'area1 - area2' or 'area1%area2'", {
-  
+
   ant_version <- "8.2.0"
   st_test <- paste0("my_study_820_", paste0(sample(letters,5),collapse = ""))
   suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
@@ -167,11 +167,11 @@ test_that("Check if writeInputTS() writes links time series with argument link '
   dat_mat_sep_1 <- c(1,3,2,4)
   nb_cols <- length(dat_mat_sep_1)
   mat_ts_sep_1 <- matrix(data = rep(dat_mat_sep_1, each = 8760), ncol = nb_cols)
-  
+
   dat_mat_sep_2 <- c(5,7,6,8)
   nb_cols <- length(dat_mat_sep_2)
   mat_ts_sep_2 <- matrix(data = rep(dat_mat_sep_2, each = 8760), ncol = nb_cols)
-  
+
   # link separator '%'
   writeInputTS(data = mat_ts_sep_1, link = paste0(area,"%",area2), type = "tsLink", opts = opts)
 
@@ -182,7 +182,7 @@ test_that("Check if writeInputTS() writes links time series with argument link '
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_indirect_link_file),
                as.data.table(mat_ts_sep_1[,seq((nb_cols/2)+1, nb_cols)]))
-  
+
   # link separator ' - '
   writeInputTS(data = mat_ts_sep_2, link = paste0(area," - ",area2), type = "tsLink", opts = opts)
 
@@ -199,46 +199,58 @@ test_that("Check if writeInputTS() writes links time series with argument link '
 
 
 # >= v860 ----
-setup_study_860(sourcedir860)
+#setup_study_860(sourcedir860)
+
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "write-input-ts", 
+              antares_version = "8.6.0"))
+
+# default area with st cluster
+area_1 = "fr"
+area_2 = "be"
+opts<-createArea(name = area_1)
+opts<-createArea(name = area_2)
+
 
 #Avoid warning related to code writed outside test_that.
-suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
+#suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
 
 ## Check column dimension ----
 test_that("create mingen file data v860", {
-  
+
   #Initialize mingen data
   M_mingen = matrix(0,8760,5)
-  
-  
-  # [management rules] for mingen data : 
-  # file mod.txt (in /series) have to be same column dimension 
+
+
+  # [management rules] for mingen data :
+  # file mod.txt (in /series) have to be same column dimension
   # or column dimension of 1 or NULL (empty file)
-  
+
   # check dimensions of mod.txt for every areas
-  path_file_mod <- file.path(opts$inputPath, "hydro", "series", 
-                             getAreas(), 
+  path_file_mod <- file.path(opts$inputPath, "hydro", "series",
+                             getAreas(),
                              "mod.txt")
-  
+
   list_dim <- lapply(path_file_mod, function(x){
     # read
     file <- fread(file = x)
     dim_file <- dim(file)[2]
   })
-  
+
   names(list_dim) <- getAreas()
-  
-  ## trivial case 
+
+  ## trivial case
   # mod.txt column dimension == 1
-  area_1 <- getAreas()[list_dim==1][1]
-  
+
+
   # write for an area with file mod.txt NULL or nb columns == 1
-  writeInputTS(area = area_1, type = "mingen", 
+  writeInputTS(area = area_1, type = "mingen",
                data = M_mingen , overwrite = TRUE, opts = opts)
-  
+
   # use antaresRead to test
   read_ts_file <- readInputTS(mingen = "all", opts = opts)
-  
+
   # tests correct reading data
   # check col name "mingen"
   testthat::expect_true("mingen" %in% names(read_ts_file))
@@ -246,71 +258,71 @@ test_that("create mingen file data v860", {
   testthat::expect_true(area_1 %in% unique(read_ts_file$area))
   # check dimension data for your area
   testthat::expect_equal(dim(M_mingen)[2], max(read_ts_file[area %in% area_1, tsId]))
-  
-  
+
+
   # mod.txt column dimension == 0 (empty file)
-  area_0 <- getAreas()[list_dim==0][1]
-  
+  #area_0 <- getAreas()[list_dim==0][1]
+
   # write for an area with file mod.txt empty columns == 0
-  writeInputTS(area = area_0, type = "mingen", 
+  writeInputTS(area = area_2, type = "mingen",
                data = M_mingen , overwrite = TRUE, opts = opts)
-  
+
   # use antaresRead to test
   read_ts_file <- readInputTS(mingen = "all", opts = opts)
-  
+
   # check your area
-  testthat::expect_true(area_0 %in% unique(read_ts_file$area))
-  
-  
+  testthat::expect_true(area_1 %in% unique(read_ts_file$area))
+
+
   ## multi columns cas for mod.txt file
-  # mod.txt column dimension >= 1 
-  area_mult <- getAreas()[list_dim>1][1]
-  
+  # mod.txt column dimension >= 1
+  #area_mult <- getAreas()[list_dim>1][1]
+
   # write for an area with file mod.txt >1 columns
   # error case cause mod.txt dimension
-  testthat::expect_error(writeInputTS(area = area_mult, type = "mingen", 
-                                      data = M_mingen , overwrite = TRUE, opts = opts), 
+  testthat::expect_error(writeInputTS(area = area_2, type = "mingen",
+                                      data = M_mingen , overwrite = TRUE, opts = opts),
                          regexp = 'mingen \'data\' must be either a 8760\\*1 or 8760\\*3 matrix.')
-  
-  # you can write only mingen file with dimension 1 
-  writeInputTS(area = area_mult, type = "mingen", 
-               data = as.matrix(M_mingen[,1]) , 
+
+  # you can write only mingen file with dimension 1
+  writeInputTS(area = area_2, type = "mingen",
+               data = as.matrix(M_mingen[,1]) ,
                overwrite = TRUE, opts = opts)
-  
+
   # use antaresRead to test
   read_ts_file <- readInputTS(mingen = "all", opts = opts)
-  
+
   # check your area
-  testthat::expect_true(area_mult %in% unique(read_ts_file$area))
+  testthat::expect_true(area_2 %in% unique(read_ts_file$area))
   # check dimension data for your area
-  testthat::expect_equal(1, max(read_ts_file[area %in% area_mult, tsId]))
-  
-  
-  
-  
-  
+  testthat::expect_equal(1, max(read_ts_file[area %in% area_2, tsId]))
+
+
+
+
+
   ## display warning message with type= "hydroSTOR" (minor update function v860)
-  
+
   # Wrong format of data, here it must be either 1 or 5 columns.
   M_hydrostor <- matrix(c(rep(8, 365), rep(5.1, 365)), nrow = 365)
-  
+
   # warning about the file format
   expect_warning(writeInputTS(area = area_1, type = "hydroSTOR", data = M_hydrostor, opts = opts),
                  regexp = "mod 'data' must be")
-  
+
 })
 
 
-## Rollback to empty file ----
+# Rollback to empty file ----
 test_that("writeInputTS() in 8.6.0 : rollback to an empty file", {
 
   ant_version <- "8.6.0"
   st_test <- paste0("my_study_860_", paste0(sample(letters,5),collapse = ""))
-  suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
+  suppressWarnings(opts <- createStudy(path = tempdir(), study_name = st_test, antares_version = ant_version))
   area <- "zone51"
-  createArea(area)
+  opts <- createArea(area)
   opts <- setSimulationPath(opts$studyPath, simulation = "input")
-  
+
   path_mingen <- file.path(opts$inputPath, "hydro", "series", area, "mingen.txt")
   mat_mingen <- matrix(6,8760,5)
   expect_error(writeInputTS(area = area,
@@ -321,43 +333,43 @@ test_that("writeInputTS() in 8.6.0 : rollback to an empty file", {
   ,regexp = "can not be updated"
   )
   expect_true(file.size(path_mingen) == 0)
-  
+
   unlink(x = opts$studyPath, recursive = TRUE)
 })
 
 
-## Error mingen.txt vs mod.txt ----
+# Error mingen.txt vs mod.txt ----
 test_that("writeInputTS() in 8.6.0 : check if there is an error when control is enabled and data is inconsistent between mingen.txt and mod.txt", {
-  
+
   ant_version <- "8.6.0"
   st_test <- paste0("my_study_860_", paste0(sample(letters,5),collapse = ""))
-  suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
+  suppressWarnings(opts <- createStudy(path = tempdir(), study_name = st_test, antares_version = ant_version))
   area <- "zone51"
-  createArea(area)
+  opts <- createArea(area)
   opts <- setSimulationPath(opts$studyPath, simulation = "input")
-  
+
   lst_yearly <- list("use heuristic" = TRUE, "follow load" = TRUE, "reservoir" = TRUE)
   lst_monthly <- list("use heuristic" = TRUE, "follow load" = TRUE, "reservoir" = FALSE)
   lst_weekly <- list("use heuristic" = TRUE, "follow load" = FALSE)
-  
+
   nb_hours_per_day <- 24
   nb_days_per_year <- 365
   nb_hours_per_year <- nb_hours_per_day * nb_days_per_year
   # Put more than 1 ts
   nb_ts <- 5
-  
+
   mat_maxpower_init <- matrix(data = rep(c(10000, 24, 0, 24), each = 365), ncol = 4)
-  
+
   mat_mingen_false <- matrix(1,nb_hours_per_year,nb_ts)
   mat_mingen_true <- matrix(-1,nb_hours_per_year,nb_ts)
   mat_mingen_init <- matrix(0,nb_hours_per_year,nb_ts)
-  
+
   mat_mod_false <- matrix(-1,nb_days_per_year,nb_ts)
   mat_mod_true <- matrix(1,nb_days_per_year,nb_ts)
   mat_mod_init <- matrix(0,nb_days_per_year,nb_ts)
-  
+
   writeHydroValues(area= area, type = "maxpower", data = mat_maxpower_init, opts = opts)
-  
+
   # YEARLY
   writeIniHydro(area, params = lst_yearly, mode = "other", opts = opts)
   # ref mod
@@ -378,7 +390,7 @@ test_that("writeInputTS() in 8.6.0 : check if there is an error when control is 
   )
   ,regexp = "can not be updated"
   )
-  
+
   # MONTHLY
   writeIniHydro(area, params = lst_monthly, mode = "other", opts = opts)
   # ref mod
@@ -399,7 +411,7 @@ test_that("writeInputTS() in 8.6.0 : check if there is an error when control is 
   )
   ,regexp = "can not be updated"
   )
-  
+
   # WEEKLY
   writeIniHydro(area, params = lst_weekly, mode = "other", opts = opts)
   # ref mod
@@ -420,47 +432,47 @@ test_that("writeInputTS() in 8.6.0 : check if there is an error when control is 
   )
   ,regexp = "can not be updated"
   )
-  
+
   unlink(x = opts$studyPath, recursive = TRUE)
-  
+
 })
 
 
-## Success mingen.txt vs mod.txt ----
+# Success mingen.txt vs mod.txt ----
 test_that("writeInputTS() in 8.6.0 : check if new data is written when control is enabled and data is consistent between mingen.txt and mod.txt", {
-  
+
   ant_version <- "8.6.0"
   st_test <- paste0("my_study_860_", paste0(sample(letters,5),collapse = ""))
-  suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
+  suppressWarnings(opts <- createStudy(path = tempdir(), study_name = st_test, antares_version = ant_version))
   area <- "zone51"
-  createArea(area)
+  opts <- createArea(area)
   opts <- setSimulationPath(opts$studyPath, simulation = "input")
-  
+
   path_mod_file <- file.path(opts$inputPath, "hydro", "series", area, "mod.txt")
   path_mingen_file <- file.path(opts$inputPath, "hydro", "series", area, "mingen.txt")
-  
+
   lst_yearly <- list("use heuristic" = TRUE, "follow load" = TRUE, "reservoir" = TRUE)
   lst_monthly <- list("use heuristic" = TRUE, "follow load" = TRUE, "reservoir" = FALSE)
   lst_weekly <- list("use heuristic" = TRUE, "follow load" = FALSE)
-  
+
   nb_hours_per_day <- 24
   nb_days_per_year <- 365
   nb_hours_per_year <- nb_hours_per_day * nb_days_per_year
   # Put more than 1 ts
   nb_ts <- 5
-  
+
   mat_maxpower_init <- matrix(data = rep(c(10000, 24, 0, 24), each = 365), ncol = 4)
-  
+
   mat_mingen_false <- matrix(1,nb_hours_per_year,nb_ts)
   mat_mingen_true <- matrix(-1,nb_hours_per_year,nb_ts)
   mat_mingen_init <- matrix(0,nb_hours_per_year,nb_ts)
-  
+
   mat_mod_false <- matrix(-1,nb_days_per_year,nb_ts)
   mat_mod_true <- matrix(1,nb_days_per_year,nb_ts)
   mat_mod_init <- matrix(0,nb_days_per_year,nb_ts)
-  
+
   writeHydroValues(area= area, type = "maxpower", data = mat_maxpower_init, opts = opts)
-  
+
   # YEARLY
   writeIniHydro(area, params = lst_yearly, mode = "other", opts = opts)
   # ref mod
@@ -475,7 +487,7 @@ test_that("writeInputTS() in 8.6.0 : check if new data is written when control i
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_mod_file),
                as.data.table(mat_mod_true))
-  
+
   # MONTHLY
   writeIniHydro(area, params = lst_monthly, mode = "other", opts = opts)
   # ref mod
@@ -490,7 +502,7 @@ test_that("writeInputTS() in 8.6.0 : check if new data is written when control i
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_mod_file),
                as.data.table(mat_mod_true))
-  
+
   # WEEKLY
   writeIniHydro(area, params = lst_weekly, mode = "other", opts = opts)
   # ref mod
@@ -505,46 +517,46 @@ test_that("writeInputTS() in 8.6.0 : check if new data is written when control i
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_mod_file),
                as.data.table(mat_mod_true))
-  
+
   unlink(x = opts$studyPath, recursive = TRUE)
-  
+
 })
 
 
-## Success when disabled control ----
+# Success when disabled control ----
 test_that("writeInputTS() in 8.6.0 : check if new data is written when control is disabled", {
-  
+
   ant_version <- "8.6.0"
   st_test <- paste0("my_study_860_", paste0(sample(letters,5),collapse = ""))
-  suppressWarnings(opts <- createStudy(path = pathstd, study_name = st_test, antares_version = ant_version))
+  suppressWarnings(opts <- createStudy(path = tempdir(), study_name = st_test, antares_version = ant_version))
   area <- "zone51"
-  createArea(area)
+  opts <- createArea(area)
   opts <- setSimulationPath(opts$studyPath, simulation = "input")
-  
+
   path_mod_file <- file.path(opts$inputPath, "hydro", "series", area, "mod.txt")
   path_mingen_file <- file.path(opts$inputPath, "hydro", "series", area, "mingen.txt")
-  
+
   lst_wo_control <- list("use heuristic" = FALSE)
-  
+
   nb_hours_per_day <- 24
   nb_days_per_year <- 365
   nb_hours_per_year <- nb_hours_per_day * nb_days_per_year
   # Put more than 1 ts
   nb_ts <- 5
-  
+
   mat_maxpower_init <- matrix(data = rep(c(10000, 24, 0, 24), each = 365), ncol = 4)
-  
+
   mat_mingen_false <- matrix(1,nb_hours_per_year,nb_ts)
   mat_mingen_true <- matrix(-1,nb_hours_per_year,nb_ts)
   mat_mingen_init <- matrix(0,nb_hours_per_year,nb_ts)
-  
+
   mat_mod_false <- matrix(-1,nb_days_per_year,nb_ts)
   mat_mod_true <- matrix(1,nb_days_per_year,nb_ts)
   mat_mod_init <- matrix(0,nb_days_per_year,nb_ts)
-  
+
   writeIniHydro(area, params = lst_wo_control, mode = "other", opts = opts)
   writeHydroValues(area= area, type = "maxpower", data = mat_maxpower_init, opts = opts)
-  
+
   # ref mod
   writeInputTS(area = area, data = mat_mod_init, type = "hydroSTOR", opts = opts)
   writeInputTS(area = area, data = mat_mingen_true, type = "mingen", opts = opts)
@@ -573,7 +585,7 @@ test_that("writeInputTS() in 8.6.0 : check if new data is written when control i
   expect_equal(antaresRead:::fread_antares(opts = opts,
                                            file = path_mod_file),
                as.data.table(mat_mod_init))
-  
+
   unlink(x = opts$studyPath, recursive = TRUE)
 })
 

--- a/tests/testthat/test-writeInputTS.R
+++ b/tests/testthat/test-writeInputTS.R
@@ -209,9 +209,10 @@ suppressWarnings(
 # default area with st cluster
 area_1 = "fr"
 area_2 = "be"
+area_3 = "ge"
 opts<-createArea(name = area_1)
 opts<-createArea(name = area_2)
-
+opts<-createArea(name = area_3)
 
 #Avoid warning related to code writed outside test_that.
 #suppressWarnings(opts <- antaresRead::setSimulationPath(study_temp_path, "input"))
@@ -242,8 +243,6 @@ test_that("create mingen file data v860", {
 
   ## trivial case
   # mod.txt column dimension == 1
-
-
   # write for an area with file mod.txt NULL or nb columns == 1
   writeInputTS(area = area_1, type = "mingen",
                data = M_mingen , overwrite = TRUE, opts = opts)
@@ -261,7 +260,7 @@ test_that("create mingen file data v860", {
 
 
   # mod.txt column dimension == 0 (empty file)
-  #area_0 <- getAreas()[list_dim==0][1]
+  area_2 <- getAreas()[list_dim==0][1]
 
   # write for an area with file mod.txt empty columns == 0
   writeInputTS(area = area_2, type = "mingen",
@@ -271,19 +270,22 @@ test_that("create mingen file data v860", {
   read_ts_file <- readInputTS(mingen = "all", opts = opts)
 
   # check your area
-  testthat::expect_true(area_1 %in% unique(read_ts_file$area))
+  testthat::expect_true(area_2 %in% unique(read_ts_file$area))
 
 
   ## multi columns cas for mod.txt file
   # mod.txt column dimension >= 1
-  #area_mult <- getAreas()[list_dim>1][1]
+ 
 
   # write for an area with file mod.txt >1 columns
   # error case cause mod.txt dimension
-  testthat::expect_error(writeInputTS(area = area_2, type = "mingen",
-                                      data = M_mingen , overwrite = TRUE, opts = opts),
-                         regexp = 'mingen \'data\' must be either a 8760\\*1 or 8760\\*3 matrix.')
-
+  ###################################################################################
+  ####### to be corrected ####
+  #area_mult <- getAreas()[list_dim>1][1]
+  #testthat::expect_error(writeInputTS(area = area_3, type = "mingen",
+  #                                    data = matrix(0,8760,5) , overwrite = TRUE, opts = opts),
+  #                       regexp = 'mingen \'data\' must be either a 8760\\*1 or 8760\\*3 matrix.')
+ ####################################################################################################
   # you can write only mingen file with dimension 1
   writeInputTS(area = area_2, type = "mingen",
                data = as.matrix(M_mingen[,1]) ,

--- a/tests/testthat/test-writeInputTS.R
+++ b/tests/testthat/test-writeInputTS.R
@@ -199,7 +199,6 @@ test_that("Check if writeInputTS() writes links time series with argument link '
 
 
 # >= v860 ----
-#setup_study_860(sourcedir860)
 
 suppressWarnings(
   createStudy(path = tempdir(), 
@@ -222,7 +221,8 @@ test_that("create mingen file data v860", {
 
   #Initialize mingen data
   M_mingen = matrix(0,8760,5)
-
+  # write TS with 3 columns for area_3 et file mod.txt
+  writeInputTS(data = matrix(12,365,3), type = "hydroSTOR", area = area_3, overwrite = TRUE, opts = opts)
 
   # [management rules] for mingen data :
   # file mod.txt (in /series) have to be same column dimension
@@ -232,8 +232,9 @@ test_that("create mingen file data v860", {
   path_file_mod <- file.path(opts$inputPath, "hydro", "series",
                              getAreas(),
                              "mod.txt")
-
-  list_dim <- lapply(path_file_mod, function(x){
+  
+ 
+   list_dim <- lapply(path_file_mod, function(x){
     # read
     file <- fread(file = x)
     dim_file <- dim(file)[2]
@@ -279,13 +280,12 @@ test_that("create mingen file data v860", {
 
   # write for an area with file mod.txt >1 columns
   # error case cause mod.txt dimension
-  ###################################################################################
-  ####### to be corrected ####
-  #area_mult <- getAreas()[list_dim>1][1]
-  #testthat::expect_error(writeInputTS(area = area_3, type = "mingen",
-  #                                    data = matrix(0,8760,5) , overwrite = TRUE, opts = opts),
-  #                       regexp = 'mingen \'data\' must be either a 8760\\*1 or 8760\\*3 matrix.')
- ####################################################################################################
+
+  area_mult <- getAreas()[list_dim>1][1]
+  testthat::expect_error(writeInputTS(area = area_mult, type = "mingen",
+                                      data = matrix(0,8760,5) , overwrite = TRUE, opts = opts),
+                        regexp = 'mingen \'data\' must be either a 8760\\*1 or 8760\\*3 matrix.')
+
   # you can write only mingen file with dimension 1
   writeInputTS(area = area_2, type = "mingen",
                data = as.matrix(M_mingen[,1]) ,


### PR DESCRIPTION
The aim is to break the dependency in unit tests with the test study stored in the `AntaresRead` package.

We will also have to rewrite some tests that depend on the `readBindingConstraints()` function.