### PR TITLE
replace stop by warning if a binding constraint is detected, adjust t…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,9 @@
 * `createBindingConstraint()` / `editBindingConstraint()` uses metadata to check the group size of time series.
 * `createBindingConstraintBulk()` checks consistency of groups passed as parameters and consistency with the study.
 * delete `antaresRead-reexports.R` and adjust scripts to have a clean package
-
+* `removeArea()` : send a warning instead of a stop if an area is referenced in a binding constraint coefficient
+* `removeLink()` : send a warning instead of a stop if a link is referenced in a binding constraint coefficient
+* `removeCluster()` : send a warning instead of a stop if a cluster is referenced in a binding constraint coefficient
 
 NEW FEATURES (Antares v8.8) :
 

--- a/R/removeArea.R
+++ b/R/removeArea.R
@@ -222,7 +222,6 @@ checkRemovedArea <- function(area, all_files = TRUE, opts = antaresRead::simOpti
   
   bc_not_remove <- union(bc_not_remove_cluster, bc_not_remove_link)
   if (!identical(bc_not_remove, character(0))) {
-    message("The following binding constraints have the area to remove in a coefficient : ", paste0(bc_not_remove, collapse = ", "))
-    stop("Can not remove the area ", name)
+    warning("The following binding constraints have the area to remove in a coefficient : ", paste0(bc_not_remove, collapse = ", "))
   }
 }

--- a/R/removeCluster.R
+++ b/R/removeCluster.R
@@ -139,8 +139,7 @@ removeClusterST <- function(area,
     if (!api_study | (api_study && !api_mocked)) {
       bc_not_remove <- detect_pattern_in_binding_constraint(pattern = paste0(area, ".", cluster_name), opts = opts)
       if (!identical(bc_not_remove, character(0))) {
-        message("The following binding constraints have the cluster to remove as a coefficient : ", paste0(bc_not_remove, collapse = ", "))
-        stop("Can not remove the cluster ", cluster_name, " in the area ", area, ".")
+        warning("The following binding constraints have the cluster to remove as a coefficient : ", paste0(bc_not_remove, collapse = ", "))
       }
     }
   }

--- a/R/removeLink.R
+++ b/R/removeLink.R
@@ -45,8 +45,7 @@ removeLink <- function(from, to, opts = antaresRead::simOptions()) {
   # check if the link can be removed safely, i.e. the link is not referenced in a binding constraint
   bc_not_remove <- detect_pattern_in_binding_constraint(pattern = c(paste0(from, "%", to), paste0(to, "%", from)), opts = opts)
   if (!identical(bc_not_remove, character(0))) {
-    message("The following binding constraints have the link to remove as a coefficient : ", paste0(bc_not_remove, collapse = ", "))
-    stop("Can not remove the link ", link)
+    warning("The following binding constraints have the link to remove as a coefficient : ", paste0(bc_not_remove, collapse = ", "))
   }
   
   # API block

--- a/tests/testthat/test-createArea.R
+++ b/tests/testthat/test-createArea.R
@@ -358,12 +358,12 @@ test_that("removeArea(): check that area is removed if it is not referenced in a
   
   # Area
   opts <- createArea(name = new_area, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
+  expect_no_warning(removeArea(name = new_area, opts = simOptions()))
   
   # Area + Link
   opts <- createArea(name = new_area, opts = simOptions())
   opts <- createLink(from = "zone1", to = new_area, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
+  expect_no_warning(removeArea(name = new_area, opts = simOptions()))
   
   # Area + Link + Binding Constraint
   opts <- createArea(name = new_area, opts = simOptions())
@@ -377,23 +377,20 @@ test_that("removeArea(): check that area is removed if it is not referenced in a
                                   coefficients = coefs,
                                   values = matrix(rep(0, nb_values_per_matrix), ncol = nb_cols_per_matrix),
                                   opts = simOptions())
-  expect_error(removeArea(name = new_area, opts = simOptions()),
-               regexp = paste0("Can not remove the area ", new_area)
+  expect_warning(removeArea(name = new_area, opts = simOptions()),
+               regexp = "The following binding constraints have the area to remove in a coefficient : "
   )
-  
-  removeBindingConstraint(name = name_bc, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
   
   new_area <- "zzone_bc_cluster"
   
   # Area
   opts <- createArea(name = new_area, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
+  expect_no_warning(removeArea(name = new_area, opts = simOptions()))
   
   # Area + Cluster
   opts <- createArea(name = new_area, opts = simOptions())
   opts <- createCluster(area = new_area, cluster_name = "nuclear", add_prefix = TRUE, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
+  expect_no_warning(removeArea(name = new_area, opts = simOptions()))
   
   # Area + Cluster + Binding Constraint
   opts <- createArea(name = new_area, opts = simOptions())
@@ -408,12 +405,11 @@ test_that("removeArea(): check that area is removed if it is not referenced in a
                                   coefficients = coefs,
                                   values = matrix(rep(0, nb_values_per_matrix), ncol = nb_cols_per_matrix),
                                   opts = simOptions())
-  expect_error(removeArea(name = new_area, opts = simOptions()),
-               regexp = paste0("Can not remove the area ", new_area)
+  expect_warning(removeArea(name = new_area, opts = simOptions()),
+                 regexp = "The following binding constraints have the area to remove in a coefficient : "
   )
   
   removeBindingConstraint(name = name_bc, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
   
   new_area <- "zzone_bc_cluster_link"
   
@@ -431,12 +427,11 @@ test_that("removeArea(): check that area is removed if it is not referenced in a
                                   coefficients = coefs,
                                   values = matrix(rep(0, nb_values_per_matrix), ncol = nb_cols_per_matrix),
                                   opts = simOptions())
-  expect_error(removeArea(name = new_area, opts = simOptions()),
-               regexp = paste0("Can not remove the area ", new_area)
+  expect_warning(removeArea(name = new_area, opts = simOptions()),
+                 regexp = "The following binding constraints have the area to remove in a coefficient : "
   )
   
   removeBindingConstraint(name = name_bc, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
   
   new_area <- "zzone_bc_cluster_link_2"
   
@@ -454,17 +449,14 @@ test_that("removeArea(): check that area is removed if it is not referenced in a
                                   coefficients = coefs,
                                   values = matrix(rep(0, nb_values_per_matrix), ncol = nb_cols_per_matrix),
                                   opts = simOptions())
-  expect_error(removeArea(name = new_area, opts = simOptions()),
-               regexp = paste0("Can not remove the area ", new_area)
+  expect_warning(removeArea(name = new_area, opts = simOptions()),
+                 regexp = "The following binding constraints have the area to remove in a coefficient : "
   )
-  
-  removeBindingConstraint(name = name_bc, opts = simOptions())
-  expect_no_error(removeArea(name = new_area, opts = simOptions()))
   
   # standard areas
   for (area in my_areas) {
-    expect_error(removeArea(name = area, opts = simOptions()),
-               regexp = paste0("Can not remove the area ", area)
+    expect_warning(removeArea(name = area, opts = simOptions()),
+                   regexp = "The following binding constraints have the area to remove in a coefficient : "
     )
   }
   

--- a/tests/testthat/test-createCluster.R
+++ b/tests/testthat/test-createCluster.R
@@ -226,9 +226,8 @@ test_that("removeCluster() : cluster is not removed if it is referenced in a bin
   
   suppressWarnings(opts <- setSimulationPath(path = opts$studyPath, simulation = "input"))
   
-  expect_error(removeCluster(area = "zone1", cluster_name = "nuclear", add_prefix = TRUE, opts = opts), regexp = "Can not remove the cluster")
-  removeBindingConstraint(name = "bc_nuclear", opts = opts)
-  expect_no_error(removeCluster(area = "zone1", cluster_name = "nuclear", add_prefix = TRUE, opts = opts))
+  expect_warning(removeCluster(area = "zone1", cluster_name = "nuclear", add_prefix = TRUE, opts = opts),
+                 regexp = "The following binding constraints have the cluster to remove as a coefficient :")
   
   unlink(x = opts$studyPath, recursive = TRUE)
 })

--- a/tests/testthat/test-createLink.R
+++ b/tests/testthat/test-createLink.R
@@ -291,12 +291,12 @@ test_that("removeLink() : link is not removed if it is referenced in a binding c
   
   suppressWarnings(opts <- setSimulationPath(path = opts$studyPath, simulation = "input"))
   
-  expect_error(removeLink(from = "zone1", to = "zone2", opts = opts), regexp = "Can not remove the link")
-  removeBindingConstraint(name = "bc_zone1", opts = opts)
-  expect_no_error(removeLink(from = "zone1", to = "zone2", opts = opts))
+  expect_warning(removeLink(from = "zone1", to = "zone2", opts = opts),
+                 regexp = "The following binding constraints have the link to remove as a coefficient :")
   
   # createLink() with overwrite to TRUE calls removeLink()
-  expect_error(createLink(from = "zone2", to = "zone3", overwrite = TRUE, opts = opts), regexp = "Can not remove the link")
+  expect_warning(createLink(from = "zone2", to = "zone3", overwrite = TRUE, opts = opts),
+                 regexp = "The following binding constraints have the link to remove as a coefficient :")
   
   pathIni <- file.path(opts$inputPath, "bindingconstraints/bindingconstraints.ini")
   bindingConstraints <- readIniFile(pathIni, stringsAsFactors = FALSE)
@@ -307,7 +307,8 @@ test_that("removeLink() : link is not removed if it is referenced in a binding c
   names(bindingConstraints[[bc_char]])[names(bindingConstraints[[bc_char]]) == "zone4%zone5"] <- "zone5%zone4"
   
   writeIni(listData = bindingConstraints, pathIni = pathIni, overwrite = TRUE)
-  expect_error(removeLink(from = "zone4", to = "zone5", opts = opts), regexp = "Can not remove the link")
+  expect_warning(removeLink(from = "zone4", to = "zone5", opts = opts),
+                 regexp = "The following binding constraints have the link to remove as a coefficient :")
   
   unlink(x = opts$studyPath, recursive = TRUE)
 })


### PR DESCRIPTION
- warning instead of stop if a link (removeLink()), a cluster(removeCluster()) or an area(removeArea()) is referenced in a binding constraint