### PR TITLE
fix creation bc in text mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ NEW FEATURES (Antares v8.8) :
 BUGFIXES :  
 
 * `createBindingConstraint()` in API mode (for study <v870) created with "hourly" timeStep all the time
+* `createBindingConstraint()` / `editBindingConstraint()` in TEXT mode, bad values in time series
 * side effects with `readClusterDesc()` / `readClusterResDesc()` / `readClusterSTDesc()` 
 
 

--- a/R/createBindingConstraint.R
+++ b/R/createBindingConstraint.R
@@ -444,22 +444,28 @@ createBindingConstraint_ <- function(bindingConstraints,
   # Write values
   # v870
   if(opts$antaresVersion>=870){
-    # names_order_ts <- c("lt", "gt", "eq")
+    # make name file + path file + code file 
+      # to write values matching operator
     name_file <- paste0(id, "_", output_operator, ".txt")
-    
     up_path <- file.path(opts$inputPath, "bindingconstraints", name_file)
     
-    lapply(up_path, function(x, df_ts= values, vect_path= up_path){
+    df <- data.frame(
+      name_file = name_file,
+      code_file = output_operator,
+      path_file =  up_path <- file.path(opts$inputPath, "bindingconstraints", name_file)
+    )
+    
+    lapply(seq(nrow(df)), function(x, df_ts= values, vect_path= up_path){
       if(identical(df_ts, character(0)))
         fwrite(x = data.table::as.data.table(df_ts), 
-               file = x, 
+               file = df[x, "path_file"], 
                col.names = FALSE, 
                row.names = FALSE, 
                sep = "\t")
       else{
-        index <- grep(x = vect_path, pattern = x)
-        fwrite(x = data.table::as.data.table(df_ts[[index]]), 
-               file = x, 
+        target_name <- df[x, "code_file"]
+        fwrite(x = data.table::as.data.table(df_ts[[target_name]]), 
+               file = df[x, "path_file"], 
                col.names = FALSE, 
                row.names = FALSE, 
                sep = "\t")

--- a/R/createBindingConstraint.R
+++ b/R/createBindingConstraint.R
@@ -134,9 +134,8 @@ createBindingConstraint <- function(name,
       identical(areas, sort(areas))
     })
     
-    if (!all(are_areas_sorted)) {
+    if (!all(are_areas_sorted)) 
       stop("The areas are not sorted alphabetically.", call. = FALSE)
-    }
   }
   
   # API block
@@ -454,21 +453,19 @@ createBindingConstraint_ <- function(bindingConstraints,
       code_file = output_operator,
       path_file =  up_path)
     
+    # write txt file(s)
     lapply(seq(nrow(df)), function(x, df_ts= values){
       if(identical(df_ts, character(0)))
-        fwrite(x = data.table::as.data.table(df_ts), 
-               file = df[x, "path_file"], 
-               col.names = FALSE, 
-               row.names = FALSE, 
-               sep = "\t")
+        data_content <- data.table::as.data.table(df_ts)
       else{
         target_name <- df[x, "code_file"]
-        fwrite(x = data.table::as.data.table(df_ts[[target_name]]), 
-               file = df[x, "path_file"], 
-               col.names = FALSE, 
-               row.names = FALSE, 
-               sep = "\t")
+        data_content <- data.table::as.data.table(df_ts[[target_name]])
       }
+      fwrite(x = data_content, 
+             file = df[x, "path_file"], 
+             col.names = FALSE, 
+             row.names = FALSE, 
+             sep = "\t")
     })
   }else{
     pathValues <- file.path(opts$inputPath, "bindingconstraints", paste0(id, ".txt"))
@@ -523,7 +520,7 @@ group_values_meta_check <- function(group_value,
   # check meta 
     # study with no BC or virgin study
   if(is.null(opts$binding)){
-    cat("\nThere is no binding constraint in this study\n")
+    cat("\nThere were no binding constraints in this study\n")
     return()
   }
   

--- a/R/createBindingConstraint.R
+++ b/R/createBindingConstraint.R
@@ -452,10 +452,9 @@ createBindingConstraint_ <- function(bindingConstraints,
     df <- data.frame(
       name_file = name_file,
       code_file = output_operator,
-      path_file =  up_path <- file.path(opts$inputPath, "bindingconstraints", name_file)
-    )
+      path_file =  up_path)
     
-    lapply(seq(nrow(df)), function(x, df_ts= values, vect_path= up_path){
+    lapply(seq(nrow(df)), function(x, df_ts= values){
       if(identical(df_ts, character(0)))
         fwrite(x = data.table::as.data.table(df_ts), 
                file = df[x, "path_file"], 

--- a/R/editBindingConstraint.R
+++ b/R/editBindingConstraint.R
@@ -241,13 +241,17 @@ editBindingConstraint <- function(name,
                            "bindingconstraints", 
                            name_file)
       
-      lapply(up_path, 
+      df <- data.frame(
+        name_file = name_file,
+        code_file = values_operator,
+        path_file =  up_path)
+      
+      lapply(seq(nrow(df)), 
              function(x, 
-                      df_ts= values, 
-                      vect_path= up_path){
-               index <- grep(x = vect_path, pattern = x)
-               fwrite(x = data.table::as.data.table(df_ts[[index]]), 
-                      file = x, 
+                      df_ts= values){
+               target_name <- df[x, "code_file"]
+               fwrite(x = data.table::as.data.table(df_ts[[target_name]]), 
+                      file = df[x, "path_file"], 
                       col.names = FALSE, 
                       row.names = FALSE, 
                       sep = "\t")

--- a/tests/testthat/test-createBindingConstraint.R
+++ b/tests/testthat/test-createBindingConstraint.R
@@ -354,7 +354,7 @@ test_that("createBindingConstraint (default group value) v8.7", {
   path_file_bc <- paste0(file.path(path_bc, "myconstraint"), 
                          operator_bc, ".txt")
   
-  # read .txt
+  # read .txt (test values)
   res <- lapply(path_file_bc, 
          antaresRead:::fread_antares, 
          opts = opts_test)
@@ -381,6 +381,22 @@ test_that("createBindingConstraint (default group value) v8.7", {
   testthat::expect_equal(bc$myconstraint2$properties$group, "default")
   testthat::expect_equal(dim(scenar_values$lt)[2], 
                          dim(bc$myconstraint2$values$less)[2])
+  
+  # for both
+  operator_bc <- c("_lt", "_gt")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, "myconstraint2"), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+    # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values$lt)))
   
   ### error dim ----
     # add BC with daily values (different columns dimension ERROR) 

--- a/tests/testthat/test-createBindingConstraint.R
+++ b/tests/testthat/test-createBindingConstraint.R
@@ -397,6 +397,61 @@ test_that("createBindingConstraint (default group value) v8.7", {
     # test just first values cause code convert 8760 to 8784 with 0
   testthat::expect_equal(head(res[[1]]), 
                          head(data.table::as.data.table(scenar_values$lt)))
+  testthat::expect_equal(head(res[[2]]), 
+                         head(data.table::as.data.table(scenar_values$gt)))
+  
+  # for greater 
+  createBindingConstraint(
+    name = "myconstraint_gr8ter",
+    values = scenar_values,
+    enabled = FALSE,
+    timeStep = "hourly",
+    operator = "greater",
+    coefficients = c("at%fr" = 1))
+  
+  bc <- readBindingConstraints()
+  
+  operator_bc <- c("_gt")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, "myconstraint_gr8ter"), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+  # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values$gt)))
+  
+  # for equal 
+  createBindingConstraint(
+    name = "myconstraint_equal",
+    values = scenar_values,
+    enabled = FALSE,
+    timeStep = "hourly",
+    operator = "equal",
+    coefficients = c("at%fr" = 1))
+  
+  bc <- readBindingConstraints()
+  
+  operator_bc <- c("_eq")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, "myconstraint_equal"), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+  # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values$eq)))
+  
   
   ### error dim ----
     # add BC with daily values (different columns dimension ERROR) 

--- a/tests/testthat/test-editBindingConstraint.R
+++ b/tests/testthat/test-editBindingConstraint.R
@@ -82,13 +82,14 @@ test_that("editBindingConstraint with 'default' group v8.7.0", {
     values = scenar_values_hourly,
     enabled = TRUE,
     timeStep = "hourly",
-    operator = "both",
+    operator = "greater",
     overwrite = TRUE,
     coefficients = data_terms)
 
   # PS : in this study, "default" have 1 column dimension
   bc <- readBindingConstraints(opts = opts_test)
     
+  ### greater to both ----
   # edit properties + values (good dimension)
     # edit "greater" to "both"
   bc_names_v870 <- bc[[name_bc]]$properties$id
@@ -115,10 +116,92 @@ test_that("editBindingConstraint with 'default' group v8.7.0", {
   testthat::expect_true(filter_year %in% "daily")
   testthat::expect_true(filter_synthesis %in% "daily")
   
-  # test values
+  # test dim values
   dim_col_values_input <- dim(scenar_values_daily$lt)[2]
   dim_col_values_edited <- dim(bc_modified[[bc_names_v870]]$values$less)[2]
   testthat::expect_equal(dim_col_values_input, dim_col_values_edited)
+  
+  # test real values
+  # for both
+  operator_bc <- c("_lt", "_gt")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, bc_names_v870), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+  # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values_daily$lt)))
+  testthat::expect_equal(head(res[[2]]), 
+                         head(data.table::as.data.table(scenar_values_daily$gt)))
+  
+  
+  
+  ### greater to equal ----
+    # edit properties + values (good dimension)
+    # edit "both" to "equal"
+  bc_names_v870 <- bc[[name_bc]]$properties$id
+  editBindingConstraint(name = bc_names_v870, 
+                        values = scenar_values_daily, 
+                        timeStep = "daily",
+                        operator = "equal", 
+                        filter_year_by_year = "daily",
+                        filter_synthesis = "daily",
+                        coefficients = list("fr%it"= 7.45))
+  
+  # test real values
+  # for equal
+  operator_bc <- c("_eq")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, bc_names_v870), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+  # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values_daily$eq)))
+  
+  ### equal to less ----
+    # edit properties + values (good dimension)
+    # edit "equal" to "less"
+  bc_names_v870 <- bc[[name_bc]]$properties$id
+  editBindingConstraint(name = bc_names_v870, 
+                        values = scenar_values_daily, 
+                        timeStep = "daily",
+                        operator = "less", 
+                        filter_year_by_year = "daily",
+                        filter_synthesis = "daily",
+                        coefficients = list("fr%it"= 7.45))
+  
+  # test real values
+  # for equal
+  operator_bc <- c("_lt")
+  path_bc <- file.path(opts_test$inputPath, "bindingconstraints")
+  path_file_bc <- paste0(file.path(path_bc, bc_names_v870), 
+                         operator_bc, ".txt")
+  
+  # read .txt (test values)
+  res <- lapply(path_file_bc, 
+                antaresRead:::fread_antares, 
+                opts = opts_test)
+  
+  # txt files (test real value)
+  # test just first values cause code convert 8760 to 8784 with 0
+  testthat::expect_equal(head(res[[1]]), 
+                         head(data.table::as.data.table(scenar_values_daily$lt)))
+
+  
+  
   
   
   # edit properties + values (bad dimension)


### PR DESCRIPTION
Bug in text mode with binding constraint creation , at least. 
The bug is present when creating TS in "greater" or "less" or "equal" mode. The values written to disk are not the correct ones.