### PR TITLE
editLink() : fix bug for NULL values for arguments filter_synthesis and filter_year_by_year

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ BUGFIXES :
 * side effects with `readClusterDesc()` / `readClusterResDesc()` / `readClusterSTDesc()`
 * Fix bug for data.table to ensure that the variable name is not a column name in `check_cluster_name()` (API + DISK) and `createClusterST()`(API)
 * Enable control of matrix dimension in `.check_bulk_object_dim()` even if the values are not in first position in the list
+* `editLink()` : avoid *NULL* value (default) for arguments *filter_synthesis* and *filter_year_by_year* to write an empty string  
 
 
 OTHER UPDATES :

--- a/R/editLink.R
+++ b/R/editLink.R
@@ -20,6 +20,7 @@
 #' @importFrom assertthat assert_that
 #' @importFrom stats setNames 
 #' @importFrom utils read.table write.table modifyList
+#' @importFrom data.table fwrite as.data.table
 #'
 #' @examples
 #' \dontrun{
@@ -125,7 +126,7 @@ editLink <- function(from,
         direct <- last_cols
         indirect <- first_cols
       }
-      tsLink <- data.table::as.data.table(tsLink)
+      tsLink <- as.data.table(tsLink)
     } else {
       warning("tsLink will be ignored since Antares version < 820.", call. = FALSE)
     }
@@ -231,8 +232,8 @@ editLink <- function(from,
   
   if (!is.null(dataLink)) {
     if (v820) {
-      data.table::fwrite(
-        x = data.table::as.data.table(dataLink), 
+      fwrite(
+        x = as.data.table(dataLink), 
         row.names = FALSE, 
         col.names = FALSE,
         sep = "\t",
@@ -244,8 +245,8 @@ editLink <- function(from,
         dataLink[, 1:2] <- dataLink[, 2:1]
         dataLink[, 4:5] <- dataLink[, 5:4]
       }
-      data.table::fwrite(
-        x = data.table::as.data.table(dataLink),
+      fwrite(
+        x = as.data.table(dataLink),
         row.names = FALSE, 
         col.names = FALSE, 
         sep = "\t",
@@ -259,7 +260,7 @@ editLink <- function(from,
   if (!is.null(tsLink)) {
     if (v820) {
       dir.create(file.path(inputPath, "links", from, "capacities"), showWarnings = FALSE)
-      data.table::fwrite(
+      fwrite(
         x = tsLink[, .SD, .SDcols = direct], 
         row.names = FALSE, 
         col.names = FALSE,
@@ -267,7 +268,7 @@ editLink <- function(from,
         scipen = 12,
         file = file.path(inputPath, "links", from, "capacities", paste0(to, "_direct.txt"))
       )
-      data.table::fwrite(
+      fwrite(
         x = tsLink[, .SD, .SDcols = indirect], 
         row.names = FALSE, 
         col.names = FALSE,

--- a/R/editLink.R
+++ b/R/editLink.R
@@ -44,14 +44,21 @@ editLink <- function(from,
                      opts = antaresRead::simOptions()) {
   
   assertthat::assert_that(inherits(opts, "simOptions"))
-
+  
+  if (!is.null(filter_synthesis)) {
+    filter_synthesis <- paste(filter_synthesis, collapse = ", ")
+  }
+  if (!is.null(filter_year_by_year)) {
+    filter_year_by_year <- paste(filter_year_by_year, collapse = ", ")
+  }
+  
   propertiesLink <- dropNulls(list(
     `hurdles-cost` = hurdles_cost,
     `transmission-capacities` = transmission_capacities,
     `asset-type` = asset_type,
     `display-comments` = display_comments,
-    `filter-synthesis` = paste(filter_synthesis,collapse = ", "),
-    `filter-year-by-year` = paste(filter_year_by_year,collapse = ", ")
+    `filter-synthesis` = filter_synthesis,
+    `filter-year-by-year` = filter_year_by_year
   ))
   
   # control areas name

--- a/tests/testthat/test-editLink.R
+++ b/tests/testthat/test-editLink.R
@@ -3,39 +3,61 @@ test_that("Edit a link filters", {
   
   pasteVectorItemsWithComma <- function(x) paste(x,collapse=", ")
 
-  opts_test <-createStudy(path = tempdir(), 
-                          study_name = "edit-link", 
-                          antares_version = "8.6.0")
+  opts_test <- suppressWarnings(createStudy(path = tempdir(), 
+                                            study_name = "edit-link", 
+                                            antares_version = "8.6.0"
+                                            )
+                                )
 
-  opts_test <- createArea(name="area1",opts=opts_test)
-  opts_test <- createArea(name="area2",opts=opts_test)
-  opts_test <- createLink(from="area1",to="area2",opts=opts_test)
+  opts_test <- createArea(name = "area1", opts = opts_test)
+  opts_test <- createArea(name = "area2", opts = opts_test)
+  opts_test <- createArea(name = "area3", opts = opts_test)
+  opts_test <- createLink(from = "area1", to = "area2", opts = opts_test)
+  opts_test <- createLink(from = "area1", to = "area3", opts = opts_test)
   
-  new_filtering_synthesis <- c("hourly","daily")
-  new_filtering_year_by_year <- c("hourly","daily")
+  new_filtering_synthesis <- c("hourly", "daily")
+  new_filtering_year_by_year <- c("hourly", "daily")
   
   
-  link_test <- getGeographicTrimming(areas="area1",opts=opts_test)$links$`area1 - area2`
+  link_test <- getGeographicTrimming(areas = "area1", opts = opts_test)[["links"]][["area1 - area2"]]
   
   testthat::expect_false(
     link_test$`filter-synthesis`==pasteVectorItemsWithComma(new_filtering_synthesis) &&
       link_test$`filter-year-by-year`==pasteVectorItemsWithComma(new_filtering_year_by_year)
   )
   
-  
   opts_test <- editLink(
-    from="area1",
-    to="area2",
-    filter_year_by_year=new_filtering_year_by_year,
-    filter_synthesis=new_filtering_synthesis,
-    opts=opts_test
+    from = "area1",
+    to = "area2",
+    filter_year_by_year = new_filtering_year_by_year,
+    filter_synthesis = new_filtering_synthesis,
+    opts = opts_test
   ) 
   
-  new_link_test <- getGeographicTrimming(areas="area1",opts=opts_test)$links$`area1 - area2`
+  new_link_test <- getGeographicTrimming(areas = "area1", opts = opts_test)[["links"]][["area1 - area2"]]
   
   testthat::expect_true(
     new_link_test$`filter-synthesis`==pasteVectorItemsWithComma(new_filtering_synthesis) &&
       new_link_test$`filter-year-by-year`==pasteVectorItemsWithComma(new_filtering_year_by_year)
   )
   
+  # Default case : filter_synthesis/filter_year_by_year NULL
+  # The goal is to test that those two properties are not overwritten if NULL is provided.
+  geo_before <- getGeographicTrimming(areas = "area1", opts = opts_test)
+  geo_before_target_link <- geo_before[["links"]][["area1 - area3"]]
+  
+  ncol <- 2
+  new_tsLink <- matrix(rep(1, 8760 * ncol), ncol = ncol) 
+  opts_test <- editLink(
+    from = "area1",
+    to = "area3",
+    tsLink = new_tsLink,
+    opts = opts_test
+  ) 
+  
+  geo_after <- getGeographicTrimming(areas = "area1", opts = opts_test)
+  geo_after_target_link <- geo_after[["links"]][["area1 - area3"]]
+  
+  expect_true(geo_before_target_link[["filter-year-by-year"]] == geo_after_target_link[["filter-year-by-year"]])
+  expect_true(geo_before_target_link[["filter-synthesis"]] == geo_after_target_link[["filter-synthesis"]])
 })


### PR DESCRIPTION
editLink() : avoid NULL values for arguments filter_synthesis and fiter_year_by_year to write an empty string and replace the previous values