### PR TITLE
editBindingConstraint() fix bug with parameter "operator"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,13 @@ NEW FEATURES (Antares v9.0) :
 
 * `createStudy()` takes into account the new format of Antares studies (e.g. 9.0, 9.15 instead of 900, 915)  
 
+BUGFIXES :  
+
+* `editBindingConstraint()` :  
+  - `operator` parameter set to NULL, by default, no longer causes an error.  
+  - To add values, the `operator` parameter is now required.  
+  - For a study version >= 832, the `filter-year-by-year` and `filter-synthesis` properties are retained in the .ini file if they are not modified. 
+
 
 GITHUB ACTIONS :  
 

--- a/R/editBindingConstraint.R
+++ b/R/editBindingConstraint.R
@@ -151,6 +151,9 @@ editBindingConstraint <- function(name,
   
   # Marginal price granularity (v8.3.2)
   if (opts$antaresVersion >= 832){
+    iniParams <- append(iniParams, 
+                        list(`filter-year-by-year` = bc_update$`filter-year-by-year`,
+                             `filter-synthesis` = bc_update$`filter-synthesis`))
     if(!is.null(filter_year_by_year))
       iniParams$`filter-year-by-year` <- filter_year_by_year
     if(!is.null(filter_synthesis))
@@ -164,19 +167,23 @@ editBindingConstraint <- function(name,
     else
       group <- "default"
     
-    values_operator <- switch(operator,
-                              less = "lt",
-                              equal = "eq",
-                              greater = "gt",
-                              both = c("lt", "gt"))
-    
-    # check group values
-    if(!is.null(values))
+    # check group values (depend of "operator")
+    if(!is.null(values)){
+      if(!is.null(operator))
+        values_operator <- switch(operator,
+                                  less = "lt",
+                                  equal = "eq",
+                                  greater = "gt",
+                                  both = c("lt", "gt"))
+      else
+        stop("To modify the 'values' you must enter the 'operator' parameter (e.g operator = \"both\")")
+      
       group_values_meta_check(group_value = group, 
                               values_data = values,
                               operator_check = operator,
                               output_operator = values_operator,
                               opts = opts)
+    }
     
   }
     

--- a/tests/testthat/test-editBindingConstraint.R
+++ b/tests/testthat/test-editBindingConstraint.R
@@ -36,7 +36,7 @@ test_that("editBindingConstraint v710", {
   
 })
 
-# v870 ----
+# v870 Scenarized RHS ----
 
 # read script to generate study v8.7.0
 sourcedir_last_study <- system.file("study_test_generator/generate_test_study_870.R", 
@@ -65,6 +65,56 @@ eq_data <- matrix(data = rep(3, 365 * n), ncol = n)
 scenar_values_daily <- list(lt= lt_data,
                              gt= gt_data, 
                              eq= eq_data)
+
+## default group ----
+test_that("editBindingConstraint paramater one by one", {
+  
+  name_bc <- "bc_minimal"
+  createBindingConstraint(name = name_bc)
+  
+  # read 
+  bc_read <- readBindingConstraints()
+  
+  # edit nothing
+  editBindingConstraint(name = name_bc)
+  
+  # read updated
+  bc_read_updated <- readBindingConstraints()
+  
+  # test if is identical 
+  testthat::expect_equal(bc_read, bc_read_updated)
+  
+  # edit  ["values"] (created by default with "both")
+    # "operator" muy be filled 
+    testthat::expect_error(
+      editBindingConstraint(name = name_bc, 
+                            values = scenar_values_hourly[c("lt", "gt")]), 
+      regexp = "To modify the 'values' you must enter the 'operator'"
+    )
+  
+  editBindingConstraint(name = name_bc, 
+                        operator = "both",
+                        values = scenar_values_hourly[c("lt", "gt")])
+  
+  # read updated
+  bc_read_updated <- readBindingConstraints()
+  
+  # test dim
+  dim_bc <- dim(bc_read_updated$bc_minimal$values$less)
+  testthat::expect_equal(dim_bc[2], 10)
+  
+  # edit  ["enabled "] (TRUE by default)
+  editBindingConstraint(name = name_bc, 
+                        enabled = FALSE)
+  
+  # read updated
+  bc_read_updated <- readBindingConstraints()
+  
+  testthat::expect_equal(bc_read_updated$bc_minimal$properties$enabled, FALSE)
+  
+ 
+  
+})
 
 ## default group ----
 test_that("editBindingConstraint with 'default' group v8.7.0", {


### PR DESCRIPTION
The “operator” parameter had to be filled in, otherwise the function would exit with an error. 
A few more minor corrections ...