### PR TITLE
ST-Storages

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -40,7 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [release/9.2]
   pull_request:
-    branches: [main, master]
+  
   release:
     types: [published]
   workflow_dispatch:
@@ -15,8 +15,8 @@ jobs:
   pkgdown:
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    # concurrency:
+      # group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -40,7 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Encoding: UTF-8
 RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 Depends: 
-    antaresRead (>= 2.4.2)
+    antaresRead (>= 2.9.1.9000)
 Imports: 
     assertthat,
     cli,
@@ -53,3 +53,5 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
+Remotes:  
+    rte-antares-rpackage/antaresRead

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
 (cf. Antares v9.1 changelog)
 
 ### Breaking changes  :  
-  - `createClusterST()` : parameter `group` is now dynamic and have no restriction
+  - `createClusterST()`/`editClusterST()` : parameter `group` is now dynamic and have no restriction  
+    - `createClusterST()` : for a study < 9.1, execution will be STOP if `group` is not included in list (see doc)  
+
 
   
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 # antaresEditObject 0.9.2.9000
 (cf. Antares v9.1 changelog)
+
+### Breaking changes  :  
+  - `createClusterST()` : parameter `group` is now dynamic and have no restriction
+
+  
+  
 (cf. Antares v9.2 changelog)
 
 # antaresEditObject 0.9.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,14 @@
 > Copyright © 2016 RTE Reseau de transport d’electricite
 
 # antaresEditObject 0.9.2.9000
-(cf. Antares v9.1 changelog)
+(cf. Antares v9.2 changelog)
 
 ### Breaking changes  :  
   - `createClusterST()`/`editClusterST()` : parameter `group` is now dynamic and have no restriction  
-    - `createClusterST()` : for a study < 9.1, execution will be STOP if `group` is not included in list (see doc)  
-
+    - `createClusterST()` : for a study < 9.2, execution will be STOP if `group` is not included in list (see doc)  
 
   
-  
-(cf. Antares v9.2 changelog)
+
 
 # antaresEditObject 0.9.0
 (cf. Antares v9 changelog)

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -110,20 +110,25 @@ createClusterST <- function(area,
   # check study version
   check_active_ST(opts = opts)
   
-  # statics groups
-  st_storage_group <- c("PSP_open", 
-                        "PSP_closed", 
-                        "Pondage", 
-                        "Battery",
-                        paste0("Other", 
-                               seq(1,5)))
-  
-  # check group
-  if (!is.null(group) && !tolower(group) %in% tolower(st_storage_group))
-    warning(
-      "Group: '", group, "' is not a valid name recognized by Antares,",
-      " you should be using one of: ", paste(st_storage_group, collapse = ", ")
-    )
+  # TODO mutualize this part with editClusterST()   
+  # `group` is dynamic (>=v9.1)
+  if(opts$antaresVersion<910){
+    # statics groups
+    st_storage_group <- c("PSP_open", 
+                          "PSP_closed", 
+                          "Pondage", 
+                          "Battery",
+                          paste0("Other", 
+                                 seq(1,5)))
+    
+    # check group
+    if (!is.null(group) && !tolower(group) %in% tolower(st_storage_group))
+      warning(
+        "Group: '", group, "' is not a valid name recognized by Antares,",
+        " you should be using one of: ", paste(st_storage_group, collapse = ", "), 
+        call. = FALSE
+      )
+  }
   
   # check area exsiting in current study
   check_area_name(area, opts)  

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -110,25 +110,8 @@ createClusterST <- function(area,
   # check study version
   check_active_ST(opts = opts)
   
-  # TODO mutualize this part with editClusterST()   
-  # `group` is dynamic (>=v9.1)
-  if(opts$antaresVersion<910){
-    # statics groups
-    st_storage_group <- c("PSP_open", 
-                          "PSP_closed", 
-                          "Pondage", 
-                          "Battery",
-                          paste0("Other", 
-                                 seq(1,5)))
-    
-    # check group
-    if (!is.null(group) && !tolower(group) %in% tolower(st_storage_group))
-      warning(
-        "Group: '", group, "' is not a valid name recognized by Antares,",
-        " you should be using one of: ", paste(st_storage_group, collapse = ", "), 
-        call. = FALSE
-      )
-  }
+  # check group
+  .check_group_st(group = group, opts = opts)
   
   # check area exsiting in current study
   check_area_name(area, opts)  
@@ -399,4 +382,30 @@ storage_values_default <- function(opts = simOptions()) {
   }
   
   return(lst_parameters)
+}
+
+
+#' function to check 'group' parameter according to version study
+#' no check 'group' for version >= 9.1 
+#' it is used in editClusterST()
+#' @noRd
+.check_group_st <- function(group, opts){
+  # `group` is dynamic (>=v9.1)
+  if(opts$antaresVersion<910){
+    # statics groups
+    st_storage_group <- c("PSP_open", 
+                          "PSP_closed", 
+                          "Pondage", 
+                          "Battery",
+                          paste0("Other", 
+                                 seq(1,5)))
+    
+    # check group
+    if (!is.null(group) && !tolower(group) %in% tolower(st_storage_group))
+      stop(
+        "Group: '", group, "' is not a valid name recognized by Antares,",
+        " you should be using one of: ", paste(st_storage_group, collapse = ", "), 
+        call. = FALSE
+      )
+  }
 }

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -386,12 +386,12 @@ storage_values_default <- function(opts = simOptions()) {
 
 
 #' function to check 'group' parameter according to version study
-#' no check 'group' for version >= 9.1 
+#' no check 'group' for version >= 9.2
 #' it is used in editClusterST()
 #' @noRd
 .check_group_st <- function(group, opts){
-  # `group` is dynamic (>=v9.1)
-  if(opts$antaresVersion<910){
+  # `group` is dynamic (>=v9.2)
+  if(opts$antaresVersion<920){
     # statics groups
     st_storage_group <- c("PSP_open", 
                           "PSP_closed", 

--- a/R/createStudy.R
+++ b/R/createStudy.R
@@ -9,9 +9,9 @@
 #' @param antares_version Antares number version.
 #' 
 #' @section Warning: 
-#' From **Antares version 9.0** onwards, versioning is only done with one number 
+#' From **Antares version 9.2** onwards, versioning is only done with one number 
 #' for the major version number and a two-digit number for the minor 
-#' version number (e.g. 9.0, 9.12, 10.58, ...).
+#' version number (e.g. 9.2, 9.35, 10.58, ...).
 #'
 #' @return Result of [antaresRead::setSimulationPath()] or [antaresRead::setSimulationPathAPI()] accordingly.
 #' @export
@@ -30,10 +30,10 @@
 #'   study_name = "my_study", 
 #'   antares_version = "8.2.0")
 #'   
-#' # with Antares study version >= 9 (max 2 digits, ex : "9.15")  
+#' # with Antares study version >= 9.2 (max 2 digits, ex : "9.25")  
 #' createStudy("path/to/simulation", 
 #'   study_name = "my_study", 
-#'   antares_version = "9.15")
+#'   antares_version = "9.25")
 #' 
 #' }
 createStudy <- function(path, study_name = "my_study", antares_version = "8.2.0") {

--- a/R/editClusterST.R
+++ b/R/editClusterST.R
@@ -38,21 +38,8 @@ editClusterST <- function(area,
   check_active_ST(opts, check_dir = TRUE)
   check_area_name(area, opts)
   
-  # statics groups
-  st_storage_group <- c("PSP_open", 
-                        "PSP_closed", 
-                        "Pondage", 
-                        "Battery",
-                        paste0("Other", 
-                               seq(1,5)))
-  
-  # check valid group
-  if (!is.null(group) && !tolower(group) %in% tolower(st_storage_group))
-    stop(
-      "Group: '", group, "' is not a valid group recognized by Antares,",
-      " you should be using one of: ", 
-      paste(st_storage_group, collapse = ", "), call. = FALSE
-    )
+  # check 'group'
+  .check_group_st(group = group, opts = opts)
   
   ##
   # check parameters (ini file)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 development:
   mode: auto
-destination: docs
+destination: docs/release920
 template:
   params:
     bootswatch: readable

--- a/man/create-study.Rd
+++ b/man/create-study.Rd
@@ -38,9 +38,9 @@ Create study on disk or with AntaREST server through the API.
 }
 \section{Warning}{
 
-From \strong{Antares version 9.0} onwards, versioning is only done with one number
+From \strong{Antares version 9.2} onwards, versioning is only done with one number
 for the major version number and a two-digit number for the minor
-version number (e.g. 9.0, 9.12, 10.58, ...).
+version number (e.g. 9.2, 9.35, 10.58, ...).
 }
 
 \examples{
@@ -51,10 +51,10 @@ createStudy("path/to/simulation",
   study_name = "my_study", 
   antares_version = "8.2.0")
   
-# with Antares study version >= 9 (max 2 digits, ex : "9.15")  
+# with Antares study version >= 9.2 (max 2 digits, ex : "9.25")  
 createStudy("path/to/simulation", 
   study_name = "my_study", 
-  antares_version = "9.15")
+  antares_version = "9.25")
 
 }
 }

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -197,7 +197,7 @@ test_that("Create short-term storage cluster (new feature v8.8.0)",{
   
   # test restrictions on 'group' parameter
   testthat::test_that("static 'group",{
-    testthat::expect_warning(
+    testthat::expect_error(
       createClusterST(area = area_test_clust, 
                       cluster_name = "bad_group", 
                       group = "not_allowed"), 

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -195,10 +195,53 @@ test_that("Create short-term storage cluster (new feature v8.8.0)",{
   testthat::expect_true("enabled"%in%names(read_prop))
   testthat::expect_true(read_prop$enabled[1]%in%TRUE)
   
+  # test restrictions on 'group' parameter
+  testthat::test_that("static 'group",{
+    testthat::expect_warning(
+      createClusterST(area = area_test_clust, 
+                      cluster_name = "bad_group", 
+                      group = "not_allowed"), 
+      regexp = paste0(
+        "Group: '", "not_allowed", "' is not a valid name recognized by Antares,"
+      )
+    )
+    
+  })
+  
   deleteStudy()
   })
 
-
+# >=9.1 ---- 
+testthat::test_that("Allow dynamic `group`",{
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage9.2", 
+                antares_version = "9.2"))
+  
+  # default area with st cluster
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
+  
+  # default 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "dynamic_grp", 
+                  group = "toto")
+  
+  # read properties
+  opts_ <- simOptions()
+  st_path <- file.path("input",
+                       "st-storage", 
+                       "clusters", 
+                       area_test_clust, 
+                       "list")
+  
+  st_file <- readIni(pathIni = st_path)
+  
+  # group has no restrictions
+  testthat::expect_equal(st_file[[names(st_file)]][["group"]], "toto")
+  
+  deleteStudy()
+})
 
 
 

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -211,7 +211,7 @@ test_that("Create short-term storage cluster (new feature v8.8.0)",{
   deleteStudy()
   })
 
-# >=9.1 ---- 
+# >=9.2 ---- 
 testthat::test_that("Allow dynamic `group`",{
   suppressWarnings(
     createStudy(path = tempdir(), 

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -200,7 +200,7 @@ test_that("Edit short-term storage cluster (new feature v8.8.0)",{
 })
 
 
-# >=9.1 ---- 
+# >=9.2 ---- 
 testthat::test_that("Allow dynamic `group`",{
   suppressWarnings(
     createStudy(path = tempdir(), 

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -41,7 +41,7 @@ test_that("edit st-storage clusters (only for study >= v8.6.0" , {
                                        group = "new group", 
                                        add_prefix = FALSE, 
                                        opts = opts_test), 
-                         regexp = "is not a valid group recognized by Antares")
+                         regexp = "is not a valid name recognized by Antares")
   testthat::expect_error(editClusterST(area = area_test, 
                                        cluster_name = "casper", 
                                        group = "Other1",
@@ -185,7 +185,7 @@ test_that("Edit short-term storage cluster (new feature v8.8.0)",{
   
   # test restrictions on 'group' parameter
   testthat::test_that("static 'group",{
-    testthat::expect_warning(
+    testthat::expect_error(
       editClusterST(area = area_test_clust, 
                       cluster_name = "default", 
                       group = "not_allowed"), 
@@ -232,7 +232,7 @@ testthat::test_that("Allow dynamic `group`",{
   st_file <- readIni(pathIni = st_path)
   
   # group has no restrictions
-  testthat::expect_equal(st_file[[names(st_file)]][["group"]], "toto")
+  testthat::expect_equal(st_file[[names(st_file)]][["group"]], "titi")
   
   deleteStudy()
 })

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -183,6 +183,57 @@ test_that("Edit short-term storage cluster (new feature v8.8.0)",{
   testthat::expect_true("enabled"%in%names(st_params))
   testthat::expect_true(st_params$enabled[1]%in%FALSE)
   
+  # test restrictions on 'group' parameter
+  testthat::test_that("static 'group",{
+    testthat::expect_warning(
+      editClusterST(area = area_test_clust, 
+                      cluster_name = "default", 
+                      group = "not_allowed"), 
+      regexp = paste0(
+        "Group: '", "not_allowed", "' is not a valid name recognized by Antares,"
+      )
+    )
+    
+  })
+  
+  deleteStudy()
+})
+
+
+# >=9.1 ---- 
+testthat::test_that("Allow dynamic `group`",{
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage9.2", 
+                antares_version = "9.2"))
+  
+  # default area with st cluster
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
+  
+  # create 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "dynamic_grp", 
+                  group = "toto")
+  
+  # edit
+  editClusterST(area = area_test_clust, 
+                cluster_name = "dynamic_grp", 
+                group = "titi")
+  
+  # read properties
+  opts_ <- simOptions()
+  st_path <- file.path("input",
+                       "st-storage", 
+                       "clusters", 
+                       area_test_clust, 
+                       "list")
+  
+  st_file <- readIni(pathIni = st_path)
+  
+  # group has no restrictions
+  testthat::expect_equal(st_file[[names(st_file)]][["group"]], "toto")
+  
   deleteStudy()
 })
 

--- a/vignettes/Antares_new_features_v92.Rmd
+++ b/vignettes/Antares_new_features_v92.Rmd
@@ -1,0 +1,25 @@
+---
+title: "Antares new features v9.2"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Antares new features v9.2}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(antaresEditObject)
+```
+
+This article will present the new features in line with **Antares v9.2** (cf  [Antares Simulator](https://antares-simulator.readthedocs.io/en/latest/user-guide/04-migration-guides/#v920))
+
+New features :  
+
+> For 'st-storages', Parameter `group` is now dynamic and have no restriction for user  


### PR DESCRIPTION
**Antares Simulator** version >= `9.2` have now no restriction on `group` for st-storages : 

- `createClusterST()` updated  
- `editClusterST()` updated
- Add new vignette
