### PR TITLE
st-storages : New parameters and Time Series

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Encoding: UTF-8
 RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 Depends: 
-    antaresRead (>= 2.9.1.9000)
+    antaresRead (>= 2.9.2.9000)
 Imports: 
     assertthat,
     cli,
@@ -53,5 +53,5 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-Remotes:  
-    rte-antares-rpackage/antaresRead
+Remotes: 
+    rte-antares-rpackage/antaresRead@release/9.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 # antaresEditObject 0.9.2.9000
 (cf. Antares v9.2 changelog)
 
+NEW FEATURES :  
+
+* `createClusterST()`/`editClusterST()` : **New properties** (*efficiencywithdrawal*, *penalize-variation-injection*, *penalize-variation-withdrawal*, see list of properties according to study version of Antares with `storage_values_default()`)
+
 ### Breaking changes  :  
   - `createClusterST()`/`editClusterST()` : parameter `group` is now dynamic and have no restriction  
   - `createClusterST()` : for a study < 9.2, execution will be STOP if `group` is not included in list (see doc)  
@@ -10,7 +14,7 @@
 
 ### DOC :  
 
-A new article exposing new features of Antares Simulator v9.2 is available [here](https://rte-antares-rpackage.github.io/antaresEditObject/release920/dev/articles/Antares_new_features_v92.html)
+A new article exposing new features of Antares Simulator v9.2 is available [here](https://rte-antares-rpackage.github.io/antaresEditObject/release920/dev/articles/Antares_new_features_v920.html)
 
   
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,9 @@
 
 NEW FEATURES :  
 
-* `createClusterST()`/`editClusterST()` : **New properties** (*efficiencywithdrawal*, *penalize-variation-injection*, *penalize-variation-withdrawal*, see list of properties according to study version of Antares with `storage_values_default()`)
+* `createClusterST()`/`editClusterST()` :  
+  - **New properties** (*efficiencywithdrawal*, *penalize-variation-injection*, *penalize-variation-withdrawal*, see list of properties according to study version of Antares with `storage_values_default()`)  
+  - **New optional time series** (cost-injection, cost-withdrawal, cost-level, cost-variation-injection, cost-variation-withdrawal)
 
 ### Breaking changes  :  
   - `createClusterST()`/`editClusterST()` : parameter `group` is now dynamic and have no restriction  

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -144,7 +144,8 @@ createClusterST <- function(area,
   
   if(!all(names(storage_parameters) %in% names_parameters))
     stop(append("Parameter 'st-storage' must be named with the following elements: ", 
-                paste0(names_parameters, collapse= ", ")))
+                paste0(names_parameters, collapse= ", ")), 
+         call. = FALSE)
   
   # check values parameters
   .st_mandatory_params(list_values = storage_parameters, opts = opts)
@@ -157,7 +158,8 @@ createClusterST <- function(area,
   for (name in names(storage_value)){
     if (!is.null(dim(get(name))))
       if (!identical(dim(get(name)), c(8760L, 1L)))
-        stop(paste0("Input data for ", name, " must be 8760*1"))
+        stop(paste0("Input data for ", name, " must be 8760*1"), 
+             call. = FALSE)
   }
   
   ## Standardize params ----
@@ -276,12 +278,12 @@ createClusterST <- function(area,
   # read previous content of ini
   previous_params <- readIniFile(file = path_clusters_ini)
   
-  # already exists ? 
+  ## check cluster already exists ----
   if (tolower(cluster_name) %in% tolower(names(previous_params)) 
       & !overwrite)
     stop(paste(cluster_name, "already exist"))
     
-  # overwrite
+  ## overwrite ----
   if(overwrite){
     if(tolower(cluster_name) %in% tolower(names(previous_params))){
       ind_cluster <- which(tolower(names(previous_params)) %in% 

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -337,6 +337,17 @@ createClusterST <- function(area,
     if(!is.null(list_values[["enabled"]]))
       assertthat::assert_that(inherits(list_values[["enabled"]], 
                                        "logical"))
+  
+  if (opts$antaresVersion >= 920){
+    .is_ratio(list_values[["efficiencywithdrawal"]], 
+              "efficiencywithdrawal")
+    if(!is.null(list_values[["penalize-variation-injection"]]))
+      assertthat::assert_that(inherits(list_values[["penalize-variation-injection"]], 
+                                       "logical"))
+    if(!is.null(list_values[["penalize-variation-withdrawal"]]))
+      assertthat::assert_that(inherits(list_values[["penalize-variation-withdrawal"]], 
+                                       "logical"))
+  }
 }
 
 .is_ratio <- function(x, mess){
@@ -379,10 +390,15 @@ storage_values_default <- function(opts = simOptions()) {
                          initialleveloptim = FALSE)
   
   if (opts$antaresVersion >= 880){
-    lst_parameters$initiallevel <- 0.5
-    lst_parameters$enabled <- TRUE
+    lst_parameters[["initiallevel"]] <- 0.5
+    lst_parameters[["enabled"]] <- TRUE
   }
   
+  if (opts$antaresVersion >= 920){
+    lst_parameters[["efficiencywithdrawal"]] <- 1
+    lst_parameters[["penalize-variation-injection"]] <- FALSE
+    lst_parameters[["penalize-variation-withdrawal"]] <- FALSE
+  }
   return(lst_parameters)
 }
 

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -22,12 +22,14 @@
 #' @param cost_variation_injection NULL
 #' @param cost_variation_withdrawal NULL
 #' @param add_prefix If `TRUE` (the default), `cluster_name` will be prefixed by area name.
-#' @param overwrite Logical, overwrite the cluster or not.
-#' @param add_prefix If `TRUE` (the default), `cluster_name` will be prefixed by area name.
 #' @param overwrite `logical`, overwrite the cluster or not.
 #' 
 #' @template opts
-#' @note   
+#' 
+#' @name createClusterST
+#' 
+#' @section note:
+#'    
 #' To write parameters to the `list.ini` file. You have function `storage_values_default()` who is called by default.
 #' This function return `list` containing properties according study version for cluster `st-storage`.  
 #'   

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -114,6 +114,18 @@
 #'                 "my_cluster",
 #'                 storage_parameters = my_parameters)
 #'                
+#'                 
+#'   # time series                  
+#' ratio_value <- matrix(0.7, 8760)
+#'
+#' # default properties with new optional TS
+#' createClusterST(area = "fr", 
+#'                 cluster_name = "good_ts_value", 
+#'                 cost_injection = ratio_value, 
+#'                 cost_withdrawal = ratio_value, 
+#'                 cost_level = ratio_value, 
+#'                 cost_variation_injection = ratio_value,
+#'                 cost_variation_withdrawal = ratio_value)               
 #' }
 #'
 createClusterST <- function(area,

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -46,6 +46,11 @@
 #'  - initiallevel = 0.5  (`numeric` \{0;1\})  
 #'  - enabled = TRUE (`logical` TRUE/FALSE)  
 #'  
+#' Study version >= "9.2" (new parameters) :  
+#'  - efficiencywithdrawal = 1 (`numeric` \{0;1\})
+#'  - `penalize-variation-injection` = FALSE (`logical` TRUE/FALSE)
+#'  - `penalize-variation-withdrawal` = FALSE `logical` TRUE/FALSE)
+#'  
 #' By default, these values don't allow you to have an active cluster (See example section.)  
 #' 
 #' 
@@ -98,6 +103,17 @@
 #'                 PMAX_injection = ratio_data, 
 #'                 lower_rule_curve = ratio_data, 
 #'                 upper_rule_curve = ratio_data)
+#'                 
+#' # for a study version >= 9.2 (new parameters)
+#' my_parameters <- storage_values_default()
+#' my_parameters$efficiencywithdrawal <- 0.5
+#' my_parameters$`penalize-variation-injection` <- TRUE
+#' my_parameters$`penalize-variation-withdrawal` <- TRUE
+#' 
+#' createClusterST(area = "my_area", 
+#'                 "my_cluster",
+#'                 storage_parameters = my_parameters)
+#'                
 #' }
 #'
 createClusterST <- function(area,

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -165,9 +165,8 @@ createClusterST <- function(area,
   ## Standardize params ----
   params_cluster <- hyphenize_names(storage_parameters)
   
-  ## cluster name prefix ----
-  if (add_prefix)
-    cluster_name <- generate_cluster_name(area = area, 
+  ## Standardize cluster name + prefix ----
+  cluster_name <- generate_cluster_name(area = area, 
                                           cluster_name = cluster_name, 
                                           add_prefix = add_prefix)
 
@@ -279,15 +278,15 @@ createClusterST <- function(area,
   previous_params <- readIniFile(file = path_clusters_ini)
   
   ## check cluster already exists ----
-  if (tolower(cluster_name) %in% tolower(names(previous_params)) 
+  if (cluster_name %in% tolower(names(previous_params)) 
       & !overwrite)
     stop(paste(cluster_name, "already exist"))
     
   ## overwrite ----
   if(overwrite){
-    if(tolower(cluster_name) %in% tolower(names(previous_params))){
+    if(cluster_name %in% tolower(names(previous_params))){
       ind_cluster <- which(tolower(names(previous_params)) %in% 
-                             tolower(cluster_name))[1]
+                             cluster_name)[1]
       previous_params[[ind_cluster]] <- params_cluster
       names(previous_params)[[ind_cluster]] <- cluster_name
     }
@@ -313,7 +312,7 @@ createClusterST <- function(area,
                      "st-storage", 
                      "series", 
                      area, 
-                     tolower(cluster_name)),
+                     cluster_name),
     recursive = TRUE, showWarnings = FALSE
   )
   
@@ -334,7 +333,7 @@ createClusterST <- function(area,
       x = data_values, row.names = FALSE, col.names = FALSE, sep = "\t",
       file = file.path(inputPath, "st-storage", "series", 
                        area, 
-                       tolower(cluster_name), 
+                       cluster_name, 
                        paste0(storage_value[[name]]$string, ".txt")))
   }
   

--- a/R/editClusterST.R
+++ b/R/editClusterST.R
@@ -15,8 +15,69 @@
 #' 
 #' @examples
 #' \dontrun{
-#' # TODO
-#' print(2+2)
+#' # study version >= "8.6.0"
+#'
+#' # edit an existing cluster (see doc approved groups)
+#' name_group <- "Pondage"
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername", 
+#'               group = name_group)
+#' 
+#' # edit properties
+#' all_params <- storage_values_default()
+#' all_params[["efficiency"]] <- 0.9
+#' all_params[["reservoircapacity"]] <- 1000
+#' all_params[["initiallevel"]] <- 0.5
+#' all_params[["withdrawalnominalcapacity"]] <- 250
+#' all_params[["injectionnominalcapacity"]] <- 200
+#' all_params[["initialleveloptim"]] <- TRUE
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername", 
+#'               storage_parameters = all_params)
+#'
+#' # edit time series
+#' inflow_data <- matrix(3, 8760)
+#' ratio_data <- matrix(0.7, 8760)
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername",
+#'               PMAX_withdrawal = ratio_data, 
+#'               inflows = inflow_data, 
+#'               PMAX_injection = ratio_data, 
+#'               lower_rule_curve = ratio_data, 
+#'               upper_rule_curve = ratio_data)
+#'
+#' # study version >= "9.2" (new parameters and TS)
+#' 
+#' # edit group (dynamic)
+#' name_group <- "MyOwnGroup"
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername", 
+#'               group = name_group)
+#'
+#' # edit properties
+#' my_parameters <- storage_values_default()
+#' my_parameters$efficiencywithdrawal <- 0.5
+#' my_parameters$`penalize-variation-injection` <- TRUE
+#' my_parameters$`penalize-variation-withdrawal` <- TRUE
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername", 
+#'               storage_parameters = my_parameters)
+#'
+#' # edit time series
+#' ratio_data <- matrix(0.7, 8760)
+#'
+#' editClusterST(area = "areaname", 
+#'               cluster_name = "clustername",
+#'               cost_injection = ratio_data, 
+#'               cost_withdrawal = ratio_data, 
+#'               cost_level = ratio_data, 
+#'               cost_variation_injection = ratio_data, 
+#'               cost_variation_withdrawal = ratio_data)
 #' }
 #' @export
 editClusterST <- function(area,

--- a/R/editClusterST.R
+++ b/R/editClusterST.R
@@ -69,13 +69,12 @@ editClusterST <- function(area,
     # check values parameters
     .st_mandatory_params(list_values = storage_parameters, opts = opts)
     
-    ### Standardize cluster name  ----
+    ### Standardize storage_parameters  ----
     params_cluster <- hyphenize_names(storage_parameters)
   }
   
-  ## cluster name prefix ----
-  if (add_prefix)
-    cluster_name <- generate_cluster_name(area, 
+  ## Standardize cluster name + prefix ----
+  cluster_name <- generate_cluster_name(area, 
                                           cluster_name, 
                                           add_prefix)
   
@@ -202,7 +201,7 @@ editClusterST <- function(area,
     # read previous content of ini
     previous_params <- readIniFile(file = path_clusters_ini)
     
-    if (!tolower(cluster_name) %in% tolower(names(previous_params)))
+    if (!cluster_name %in% tolower(names(previous_params)))
       stop(
         "'", 
         cluster_name, 
@@ -213,7 +212,7 @@ editClusterST <- function(area,
     
     # select existing cluster
     ind_cluster <- which(tolower(names(previous_params)) %in% 
-                           tolower(cluster_name))[1]
+                           cluster_name)[1]
     previous_params[[ind_cluster]] <- utils::modifyList(x = previous_params[[ind_cluster]], 
                                                         val = params_cluster)
     names(previous_params)[[ind_cluster]] <- cluster_name
@@ -237,8 +236,8 @@ editClusterST <- function(area,
   path_txt_file <- file.path(opts$inputPath, 
                              "st-storage", 
                              "series", 
-                             tolower(area), 
-                             tolower(cluster_name))
+                             area, 
+                             cluster_name)
   
   # list of params of TS 
   list_local_params <- list(PMAX_injection = PMAX_injection,
@@ -258,8 +257,9 @@ editClusterST <- function(area,
       # name file
       name_file <- list_local_values_params[[x_val]][["string"]]
       # write disk
+      dt_to_write <- as.data.table(list_local_params[[x_val]])
       fwrite(
-        x = list_local_params[[x_val]], 
+        x = dt_to_write, 
         row.names = FALSE, 
         col.names = FALSE, 
         sep = "\t",

--- a/R/editClusterST.R
+++ b/R/editClusterST.R
@@ -5,21 +5,19 @@
 #' 
 #' Edit parameters and time series of an existing `st-storage` cluster (Antares studies >= v8.6.0).
 #' 
-#' @param area The area where to create the cluster.
-#' @param cluster_name Name for the cluster, it will prefixed by area name, unless you set `add_prefix = FALSE`.
-#' @param group Group of the cluster, one of : "PSP_open", "PSP_closed", "Pondage", "Battery", "Other". It corresponds to the type of stockage.
-#' @param storage_parameters Parameters to write in the Ini file. 
-#' @param PMAX_injection modulation of charging capacity on an 8760-hour basis. The values are float between 0 and 1.
-#' @param PMAX_withdrawal modulation of discharging capacity on an 8760-hour basis. The values are float between 0 and 1.
-#' @param inflows imposed withdrawals from the stock for other uses, The values are integer.
-#' @param lower_rule_curve This is the lower limit for filling the stock imposed each hour. The values are float between 0 and 1.
-#' @param upper_rule_curve This is the upper limit for filling the stock imposed each hour. The values are float between 0 and 1.
-#' @param add_prefix If `TRUE` (the default), `cluster_name` will be prefixed by area name.
-#' 
+#' @inheritParams createClusterST
 #' @template opts
 #' 
-#' @seealso [createClusterST()] to edit existing clusters, [removeClusterST()] to remove clusters.
+#' @note
+#' Put only properties or TS value you want to edit (see `examples` section).
 #' 
+#' @seealso [createClusterST()], [removeClusterST()]
+#' 
+#' @examples
+#' \dontrun{
+#' # TODO
+#' print(2+2)
+#' }
 #' @export
 editClusterST <- function(area,
                           cluster_name, 
@@ -30,6 +28,11 @@ editClusterST <- function(area,
                           inflows = NULL,
                           lower_rule_curve = NULL,
                           upper_rule_curve = NULL,
+                          cost_injection = NULL,
+                          cost_withdrawal = NULL,
+                          cost_level = NULL,
+                          cost_variation_injection = NULL,
+                          cost_variation_withdrawal = NULL,
                           add_prefix = TRUE, 
                           opts = antaresRead::simOptions()) {
 

--- a/R/removeCluster.R
+++ b/R/removeCluster.R
@@ -84,23 +84,27 @@ removeClusterST <- function(area,
   
   cluster_type <- match.arg(cluster_type)
   
+  # tolower area ----
   area <- tolower(area)
+  #check area ----
   check_area_name(area, opts)
   api_study <- is_api_study(opts)
   is_thermal <- identical(cluster_type, "thermal")
   
   # add prefix to cluster's name
-  cluster_name <- generate_cluster_name(area, cluster_name, add_prefix)
+  cluster_name <- generate_cluster_name(area, 
+                                        cluster_name, 
+                                        add_prefix)
   
   # check if the cluster can be removed safely, i.e. the cluster is not referenced in a binding constraint
   if (is_thermal) {
     if (!api_study) {
-      bc_not_remove <- detect_pattern_in_binding_constraint(pattern = paste0(area, ".", cluster_name), 
-                                                            opts = opts)
+      bc_not_remove <- detect_pattern_in_binding_constraint(
+        pattern = paste0(area, ".", cluster_name), 
+        opts = opts)
       if (!identical(bc_not_remove, character(0))) 
         warning("The following binding constraints have the cluster to remove as a coefficient : ", 
                 paste0(bc_not_remove, collapse = ", "))
-      
     }
   }
   
@@ -144,7 +148,7 @@ removeClusterST <- function(area,
   # read previous content of ini
   previous_params <- readIniFile(file = path_clusters_ini)
   
-  # cluster indice
+  # check cluster name ----
   idx <- which(tolower(names(previous_params)) %in% cluster_name)
   if (length(idx) < 1)
     warning("Cluster '", cluster_name, "' you want to remove doesn't seem to exist in area '", area, "'.")

--- a/R/utils.R
+++ b/R/utils.R
@@ -146,14 +146,15 @@ detect_pattern_in_binding_constraint <- function(pattern, opts = antaresRead::si
   return(bc_not_remove)
 }
 
-
+# standardize : tolower params + manage prefix
 generate_cluster_name <- function(area, cluster_name, add_prefix) {
-  
   cluster_name <- tolower(cluster_name)
+  area <- tolower(area)
   
-  if (add_prefix) {
-    cluster_name <- paste(tolower(area), cluster_name, sep = "_")
-  }
+  if (add_prefix) 
+    cluster_name <- paste(area, 
+                          cluster_name, 
+                          sep = "_")
   
   return(cluster_name)
 }

--- a/man/createClusterST.Rd
+++ b/man/createClusterST.Rd
@@ -92,6 +92,13 @@ Study version >= "8.8.0" (update + new parameter) :
 \item enabled = TRUE (\code{logical} TRUE/FALSE)
 }
 
+Study version >= "9.2" (new parameters) :
+\itemize{
+\item efficiencywithdrawal = 1 (\code{numeric} \{0;1\})
+\item \code{penalize-variation-injection} = FALSE (\code{logical} TRUE/FALSE)
+\item \code{penalize-variation-withdrawal} = FALSE \code{logical} TRUE/FALSE)
+}
+
 By default, these values don't allow you to have an active cluster (See example section.)
 }
 
@@ -133,6 +140,17 @@ createClusterST(area = "my_area",
                 PMAX_injection = ratio_data, 
                 lower_rule_curve = ratio_data, 
                 upper_rule_curve = ratio_data)
+                
+# for a study version >= 9.2 (new parameters)
+my_parameters <- storage_values_default()
+my_parameters$efficiencywithdrawal <- 0.5
+my_parameters$`penalize-variation-injection` <- TRUE
+my_parameters$`penalize-variation-withdrawal` <- TRUE
+
+createClusterST(area = "my_area", 
+                "my_cluster",
+                storage_parameters = my_parameters)
+               
 }
 
 }

--- a/man/createClusterST.Rd
+++ b/man/createClusterST.Rd
@@ -150,7 +150,18 @@ my_parameters$`penalize-variation-withdrawal` <- TRUE
 createClusterST(area = "my_area", 
                 "my_cluster",
                 storage_parameters = my_parameters)
-               
+                
+  # time series                  
+ratio_value <- matrix(0.7, 8760)
+
+# default properties with new optional TS
+createClusterST(area = "fr", 
+                cluster_name = "good_ts_value", 
+                cost_injection = ratio_value, 
+                cost_withdrawal = ratio_value, 
+                cost_level = ratio_value, 
+                cost_variation_injection = ratio_value,
+                cost_variation_withdrawal = ratio_value)               
 }
 
 }

--- a/man/createClusterST.Rd
+++ b/man/createClusterST.Rd
@@ -14,6 +14,11 @@ createClusterST(
   inflows = NULL,
   lower_rule_curve = NULL,
   upper_rule_curve = NULL,
+  cost_injection = NULL,
+  cost_withdrawal = NULL,
+  cost_level = NULL,
+  cost_variation_injection = NULL,
+  cost_variation_withdrawal = NULL,
   add_prefix = TRUE,
   overwrite = FALSE,
   opts = antaresRead::simOptions()
@@ -24,8 +29,8 @@ createClusterST(
 
 \item{cluster_name}{Name for the cluster, it will prefixed by area name, unless you set \code{add_prefix = FALSE}.}
 
-\item{group}{Group of the cluster, one of : "PSP_open", "PSP_closed", "Pondage", "Battery", "Other".
-It corresponds to the type of stockage.}
+\item{group}{Group of the cluster, one of : \emph{{PSP_open, PSP_closed, Pondage, Battery, Other}}.
+It corresponds to the type of stockage (\strong{dynamic name for Antares version >= 9.2}).}
 
 \item{storage_parameters}{\code{list } Parameters to write in the Ini file (see \code{Note}).}
 
@@ -40,9 +45,19 @@ generation or consumption on the system \code{numeric} \{<0;>0\} (8760*1).}
 
 \item{upper_rule_curve}{This is the upper limit for filling the stock imposed each hour. \code{numeric} \{0;1\} (8760*1).}
 
+\item{cost_injection}{NULL}
+
+\item{cost_withdrawal}{NULL}
+
+\item{cost_level}{NULL}
+
+\item{cost_variation_injection}{NULL}
+
+\item{cost_variation_withdrawal}{NULL}
+
 \item{add_prefix}{If \code{TRUE} (the default), \code{cluster_name} will be prefixed by area name.}
 
-\item{overwrite}{Logical, overwrite the cluster or not.}
+\item{overwrite}{\code{logical}, overwrite the cluster or not.}
 
 \item{opts}{List of simulation parameters returned by the function
 \code{\link[antaresRead:setSimulationPath]{antaresRead::setSimulationPath()}}}

--- a/man/createClusterST.Rd
+++ b/man/createClusterST.Rd
@@ -70,7 +70,9 @@ An updated list containing various information about the simulation.
 
 Create a new ST-storage cluster for >= v8.6.0 Antares studies.
 }
-\note{
+\section{note}{
+
+
 To write parameters to the \code{list.ini} file. You have function \code{storage_values_default()} who is called by default.
 This function return \code{list} containing properties according study version for cluster \code{st-storage}.
 
@@ -92,6 +94,7 @@ Study version >= "8.8.0" (update + new parameter) :
 
 By default, these values don't allow you to have an active cluster (See example section.)
 }
+
 \examples{
 \dontrun{
 

--- a/man/editClusterST.Rd
+++ b/man/editClusterST.Rd
@@ -72,8 +72,69 @@ Put only properties or TS value you want to edit (see \code{examples} section).
 }
 \examples{
 \dontrun{
-# TODO
-print(2+2)
+# study version >= "8.6.0"
+
+# edit an existing cluster (see doc approved groups)
+name_group <- "Pondage"
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername", 
+              group = name_group)
+
+# edit properties
+all_params <- storage_values_default()
+all_params[["efficiency"]] <- 0.9
+all_params[["reservoircapacity"]] <- 1000
+all_params[["initiallevel"]] <- 0.5
+all_params[["withdrawalnominalcapacity"]] <- 250
+all_params[["injectionnominalcapacity"]] <- 200
+all_params[["initialleveloptim"]] <- TRUE
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername", 
+              storage_parameters = all_params)
+
+# edit time series
+inflow_data <- matrix(3, 8760)
+ratio_data <- matrix(0.7, 8760)
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername",
+              PMAX_withdrawal = ratio_data, 
+              inflows = inflow_data, 
+              PMAX_injection = ratio_data, 
+              lower_rule_curve = ratio_data, 
+              upper_rule_curve = ratio_data)
+
+# study version >= "9.2" (new parameters and TS)
+
+# edit group (dynamic)
+name_group <- "MyOwnGroup"
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername", 
+              group = name_group)
+
+# edit properties
+my_parameters <- storage_values_default()
+my_parameters$efficiencywithdrawal <- 0.5
+my_parameters$`penalize-variation-injection` <- TRUE
+my_parameters$`penalize-variation-withdrawal` <- TRUE
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername", 
+              storage_parameters = my_parameters)
+
+# edit time series
+ratio_data <- matrix(0.7, 8760)
+
+editClusterST(area = "areaname", 
+              cluster_name = "clustername",
+              cost_injection = ratio_data, 
+              cost_withdrawal = ratio_data, 
+              cost_level = ratio_data, 
+              cost_variation_injection = ratio_data, 
+              cost_variation_withdrawal = ratio_data)
 }
 }
 \seealso{

--- a/man/editClusterST.Rd
+++ b/man/editClusterST.Rd
@@ -14,6 +14,11 @@ editClusterST(
   inflows = NULL,
   lower_rule_curve = NULL,
   upper_rule_curve = NULL,
+  cost_injection = NULL,
+  cost_withdrawal = NULL,
+  cost_level = NULL,
+  cost_variation_injection = NULL,
+  cost_variation_withdrawal = NULL,
   add_prefix = TRUE,
   opts = antaresRead::simOptions()
 )
@@ -23,19 +28,31 @@ editClusterST(
 
 \item{cluster_name}{Name for the cluster, it will prefixed by area name, unless you set \code{add_prefix = FALSE}.}
 
-\item{group}{Group of the cluster, one of : "PSP_open", "PSP_closed", "Pondage", "Battery", "Other". It corresponds to the type of stockage.}
+\item{group}{Group of the cluster, one of : \emph{{PSP_open, PSP_closed, Pondage, Battery, Other}}.
+It corresponds to the type of stockage (\strong{dynamic name for Antares version >= 9.2}).}
 
-\item{storage_parameters}{Parameters to write in the Ini file.}
+\item{storage_parameters}{\code{list } Parameters to write in the Ini file (see \code{Note}).}
 
-\item{PMAX_injection}{modulation of charging capacity on an 8760-hour basis. The values are float between 0 and 1.}
+\item{PMAX_injection}{Modulation of charging capacity on an 8760-hour basis. \code{numeric} \{0;1\} (8760*1).}
 
-\item{PMAX_withdrawal}{modulation of discharging capacity on an 8760-hour basis. The values are float between 0 and 1.}
+\item{PMAX_withdrawal}{Modulation of discharging capacity on an 8760-hour basis. \code{numeric} \{0;1\} (8760*1).}
 
-\item{inflows}{imposed withdrawals from the stock for other uses, The values are integer.}
+\item{inflows}{Algebraic deviation of the state of charge of the storage, which does not induce any power
+generation or consumption on the system \code{numeric} \{<0;>0\} (8760*1).}
 
-\item{lower_rule_curve}{This is the lower limit for filling the stock imposed each hour. The values are float between 0 and 1.}
+\item{lower_rule_curve}{This is the lower limit for filling the stock imposed each hour. \code{numeric} \{0;1\} (8760*1).}
 
-\item{upper_rule_curve}{This is the upper limit for filling the stock imposed each hour. The values are float between 0 and 1.}
+\item{upper_rule_curve}{This is the upper limit for filling the stock imposed each hour. \code{numeric} \{0;1\} (8760*1).}
+
+\item{cost_injection}{NULL}
+
+\item{cost_withdrawal}{NULL}
+
+\item{cost_level}{NULL}
+
+\item{cost_variation_injection}{NULL}
+
+\item{cost_variation_withdrawal}{NULL}
 
 \item{add_prefix}{If \code{TRUE} (the default), \code{cluster_name} will be prefixed by area name.}
 
@@ -50,6 +67,15 @@ An updated list containing various information about the simulation.
 
 Edit parameters and time series of an existing \code{st-storage} cluster (Antares studies >= v8.6.0).
 }
+\note{
+Put only properties or TS value you want to edit (see \code{examples} section).
+}
+\examples{
+\dontrun{
+# TODO
+print(2+2)
+}
+}
 \seealso{
-\code{\link[=createClusterST]{createClusterST()}} to edit existing clusters, \code{\link[=removeClusterST]{removeClusterST()}} to remove clusters.
+\code{\link[=createClusterST]{createClusterST()}}, \code{\link[=removeClusterST]{removeClusterST()}}
 }

--- a/tests/testthat/test-RemoveClusterST.R
+++ b/tests/testthat/test-RemoveClusterST.R
@@ -1,152 +1,219 @@
 # >=860 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage", 
+              antares_version = "8.6.0"))
 
-test_that("New feature v8.6", {
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage", 
-                antares_version = "8.6.0"))
+# just need at least one area
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+test_that("Check area", {
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "check_area")
   
-  # just need at least one area
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
+  expect_error(
+    removeClusterST(area = "check_area_area", 
+                    cluster_name = "check_area"), 
+    regexp = "'check_area_area' is not a valid area name, possible names are: al"
+  )
   
-  testthat::test_that("remove the only one cluster", {
-    # at least need 1 st cluster
-    createClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # remove cluster
-    removeClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # removed from ini file ?
-    
-    # read prop
-    path_st_ini <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             area_test_clust,
-                             "list")
-    
-    read_ini <- antaresRead::readIni(path_st_ini)
-    target_prop <- read_ini[[paste(area_test_clust, 
-                                   "cluster_init",
-                                   sep = "_")]]
-    
-    testthat::expect_null(target_prop)
-    
-    # remove directory ? 
-    path_st_dir <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             "series",
-                             area_test_clust,
-                             "al_cluster_init")
-    
-    testthat::expect_false(dir.exists(path_st_dir))
+  test_that("no case sensitive", {
+    expect_no_error(
+      removeClusterST(area = "AL", 
+                      cluster_name = "check_area"))
   })
-  
-  deleteStudy()
 })
+
+test_that("Check cluster name", {
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "check_cluster_name")
+  
+  expect_warning(
+    removeClusterST(area = area_test_clust, 
+                    cluster_name = "check_cluster"), 
+    regexp = "Cluster 'al_check_cluster' you want to remove doesn't seem to exist in area 'al'"
+  )
+  
+  test_that("no case sensitive", {
+    expect_no_warning(
+      removeClusterST(area = area_test_clust, 
+                      cluster_name = "check_ClusteR_NAME"))
+  })
+})
+
+test_that("remove with 'prefix=TRUE'", {
+  # at least need 1 st cluster
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "prefix")
+  
+  # remove cluster
+  removeClusterST(area = area_test_clust, 
+                  cluster_name = "prefix")
+  
+  # removed from ini file ?
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "prefix",
+                                 sep = "_")]]
+  
+  expect_null(target_prop)
+  
+  # remove directory ? 
+  path_st_dir <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           "series",
+                           area_test_clust,
+                           "al_cluster_init")
+  
+  expect_false(dir.exists(path_st_dir))
+})
+
+test_that("remove with 'prefix=FALSE'",{
+  # no prefix
+  createClusterST(
+    area = area_test_clust, 
+    cluster_name = "no_prefix")
+  
+  # no prefix (add area)
+  removeClusterST(
+    area = area_test_clust, 
+    cluster_name = "al_no_prefix", 
+    add_prefix = FALSE)
+  
+  # removed from ini file ?
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "al_no_prefix",
+                                 sep = "_")]]
+  
+  expect_null(target_prop)
+  
+  # remove directory ? 
+  path_st_dir <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           "series",
+                           area_test_clust,
+                           "al_no_prefix")
+  
+  expect_false(dir.exists(path_st_dir))
+})
+
+deleteStudy()
+
 
 # >=880 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage", 
+              antares_version = "8.8.0"))
 
-testthat::test_that("New feature v8.8", {
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage", 
-                antares_version = "8.8.0"))
+# just need at least one area
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+test_that("Remove cluster", {
+  # at least need 1 st cluster
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init")
   
-  # just need at least one area
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
+  # remove cluster
+  removeClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init")
   
-  testthat::test_that("remove the only one cluster", {
-    # at least need 1 st cluster
-    createClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # remove cluster
-    removeClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # removed from ini file ?
-    
-    # read prop
-    path_st_ini <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             area_test_clust,
-                             "list")
-    
-    read_ini <- antaresRead::readIni(path_st_ini)
-    target_prop <- read_ini[[paste(area_test_clust, 
-                                   "cluster_init",
-                                   sep = "_")]]
-    
-    testthat::expect_null(target_prop)
-    
-    # remove directory ? 
-    path_st_dir <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             "series",
-                             area_test_clust,
-                             "al_cluster_init")
-    
-    testthat::expect_false(dir.exists(path_st_dir))
-  })
+  # removed from ini file ?
   
-  deleteStudy()
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "cluster_init",
+                                 sep = "_")]]
+  
+  expect_null(target_prop)
+  
+  # remove directory ? 
+  path_st_dir <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           "series",
+                           area_test_clust,
+                           "al_cluster_init")
+  
+  expect_false(dir.exists(path_st_dir))
 })
+
+deleteStudy()
+
 
 # >=920 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage", 
+              antares_version = "9.2"))
 
-testthat::test_that("New feature v9.2", {
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage", 
-                antares_version = "9.2"))
+# just need at least one area
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+test_that("Remove cluster", {
+  # at least need 1 st cluster
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init")
   
-  # just need at least one area
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
+  # remove cluster
+  removeClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init")
   
-  testthat::test_that("remove the only one cluster", {
-    # at least need 1 st cluster
-    createClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # remove cluster
-    removeClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init")
-    
-    # removed from ini file ?
-    
-    # read prop
-    path_st_ini <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             area_test_clust,
-                             "list")
-    
-    read_ini <- antaresRead::readIni(path_st_ini)
-    target_prop <- read_ini[[paste(area_test_clust, 
-                                   "cluster_init",
-                                   sep = "_")]]
-    
-    testthat::expect_null(target_prop)
-    
-    # remove directory ? 
-    path_st_dir <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             "series",
-                             area_test_clust,
-                             "al_cluster_init")
-    
-    testthat::expect_false(dir.exists(path_st_dir))
-  })
+  # removed from ini file ?
   
-  deleteStudy()
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "cluster_init",
+                                 sep = "_")]]
+  
+  expect_null(target_prop)
+  
+  # remove directory ? 
+  path_st_dir <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           "series",
+                           area_test_clust,
+                           "al_cluster_init")
+  
+  expect_false(dir.exists(path_st_dir))
 })
+
+deleteStudy()
+

--- a/tests/testthat/test-RemoveClusterST.R
+++ b/tests/testthat/test-RemoveClusterST.R
@@ -1,0 +1,10 @@
+# >=860 ----
+
+testthat::test_that("remove st storage", {
+  # # RemoveClusterST (if no cluster => function read return error => see readClusterDesc tests)
+  # opts_test <- removeClusterST(area = area_test_clust, "cluster1", 
+  #                              opts = opts_test)
+  # 
+  # testthat::expect_false(paste(area_test_clust, "cluster1", sep = "_") %in% 
+  #                          levels(readClusterSTDesc(opts = opts_test)$cluster))
+})

--- a/tests/testthat/test-RemoveClusterST.R
+++ b/tests/testthat/test-RemoveClusterST.R
@@ -1,10 +1,152 @@
 # >=860 ----
 
-testthat::test_that("remove st storage", {
-  # # RemoveClusterST (if no cluster => function read return error => see readClusterDesc tests)
-  # opts_test <- removeClusterST(area = area_test_clust, "cluster1", 
-  #                              opts = opts_test)
-  # 
-  # testthat::expect_false(paste(area_test_clust, "cluster1", sep = "_") %in% 
-  #                          levels(readClusterSTDesc(opts = opts_test)$cluster))
+test_that("New feature v8.6", {
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage", 
+                antares_version = "8.6.0"))
+  
+  # just need at least one area
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
+  
+  testthat::test_that("remove the only one cluster", {
+    # at least need 1 st cluster
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # remove cluster
+    removeClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # removed from ini file ?
+    
+    # read prop
+    path_st_ini <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             area_test_clust,
+                             "list")
+    
+    read_ini <- antaresRead::readIni(path_st_ini)
+    target_prop <- read_ini[[paste(area_test_clust, 
+                                   "cluster_init",
+                                   sep = "_")]]
+    
+    testthat::expect_null(target_prop)
+    
+    # remove directory ? 
+    path_st_dir <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             "series",
+                             area_test_clust,
+                             "al_cluster_init")
+    
+    testthat::expect_false(dir.exists(path_st_dir))
+  })
+  
+  deleteStudy()
+})
+
+# >=880 ----
+
+testthat::test_that("New feature v8.8", {
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage", 
+                antares_version = "8.8.0"))
+  
+  # just need at least one area
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
+  
+  testthat::test_that("remove the only one cluster", {
+    # at least need 1 st cluster
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # remove cluster
+    removeClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # removed from ini file ?
+    
+    # read prop
+    path_st_ini <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             area_test_clust,
+                             "list")
+    
+    read_ini <- antaresRead::readIni(path_st_ini)
+    target_prop <- read_ini[[paste(area_test_clust, 
+                                   "cluster_init",
+                                   sep = "_")]]
+    
+    testthat::expect_null(target_prop)
+    
+    # remove directory ? 
+    path_st_dir <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             "series",
+                             area_test_clust,
+                             "al_cluster_init")
+    
+    testthat::expect_false(dir.exists(path_st_dir))
+  })
+  
+  deleteStudy()
+})
+
+# >=920 ----
+
+testthat::test_that("New feature v9.2", {
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage", 
+                antares_version = "9.2"))
+  
+  # just need at least one area
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
+  
+  testthat::test_that("remove the only one cluster", {
+    # at least need 1 st cluster
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # remove cluster
+    removeClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init")
+    
+    # removed from ini file ?
+    
+    # read prop
+    path_st_ini <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             area_test_clust,
+                             "list")
+    
+    read_ini <- antaresRead::readIni(path_st_ini)
+    target_prop <- read_ini[[paste(area_test_clust, 
+                                   "cluster_init",
+                                   sep = "_")]]
+    
+    testthat::expect_null(target_prop)
+    
+    # remove directory ? 
+    path_st_dir <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             "series",
+                             area_test_clust,
+                             "al_cluster_init")
+    
+    testthat::expect_false(dir.exists(path_st_dir))
+  })
+  
+  deleteStudy()
 })

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -1,410 +1,217 @@
 
 # >=860 ----
-test_that("New feature v8.6",{
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage", 
-                antares_version = "8.6.0"))
-  
-  # just need at least one area
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
-  
-  testthat::test_that("study opts parameters",{
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err",
-        opts = list(studyName="test",
-                    studyPath="C:/Users/beta/AppData/Local/Temp/RtmpQtOZyt/st-storage")), 
-      regexp = "opts does not inherit from class simOptions"
-    )
-  })
-  
-  testthat::test_that("create cluster only for >=8.6",{
-    bad_opts <- simOptions()
-    bad_opts$antaresVersion <- 850
-    
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err",
-        opts = bad_opts), 
-      regexp = "only available if using Antares >= 8.6.0"
-    )
-  })
-  
-  testthat::test_that("Check group",{
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        group = "myGroup"), 
-      regexp = "Group: 'myGroup' is not a valid name recognized by Antares"
-    )
-  })
-  
-  testthat::test_that("Check area",{
-    testthat::expect_error(
-      createClusterST(
-        area = "area_test_clust", 
-        cluster_name = "err"), 
-      regexp = "'area_test_clust' is not a valid area name, possible names are: al"
-    )
-  })
-  
-  testthat::test_that("Check input list 'storage_parameters'",{
-    # respect list format
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = c(efficiency=1)), 
-      regexp = "storage_parameters does not inherit from class list"
-    )
-    
-    # list with formatted names
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiencyy=1)), 
-      regexp = "Parameter 'st-storage' must be named with the following elements: efficiency, reservoircapacity"
-    )
-    
-    # check values parameters
-    # check is ratio ? 
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 2, 
-                                  reservoircapacity = 100)), 
-      regexp = "efficiency must be in range 0-1"
-    )
-    
-    # check positive capacity ? 
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 0.9, 
-                                  reservoircapacity = -100)), 
-      regexp = "reservoircapacity must be >= 0"
-    )
-    
-    # check is logical ? 
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 0.9, 
-                                  reservoircapacity = 100,
-                                  initialleveloptim = "false")), 
-      regexp = 'list_values\\[\\[\\"initialleveloptim\\"\\]\\] does not inherit from class logical'
-    )
-  })
-  
-  
-  testthat::test_that("Check dimension TS input",{
-    # test col dim
-    bad_matrix_data_dim <- matrix(1, 8760*2, ncol = 2)
-    
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        PMAX_injection = bad_matrix_data_dim), 
-      regexp = "Input data for PMAX_injection must be 8760\\*1"
-    )
-    
-    # test raw dim
-    bad_matrix_data_dim <- matrix(1, 8784)
-    
-    testthat::expect_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        PMAX_injection = bad_matrix_data_dim), 
-      regexp = "Input data for PMAX_injection must be 8760\\*1"
-    )
-  })
-  
-  testthat::test_that("Prefix is working?",{
-    # default with prefix
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage", 
+              antares_version = "8.6.0"))
+
+# just need at least one area
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+test_that("study opts parameters",{
+   expect_error(
     createClusterST(
       area = area_test_clust, 
-      cluster_name = "prefix")
-    
-    # no prefix
-    createClusterST(
-      area = area_test_clust, 
-      cluster_name = "no_prefix", 
-      add_prefix = FALSE)
-    
-    # read prop
-    path_st_ini <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             area_test_clust,
-                             "list")
-    
-    read_ini <- antaresRead::readIni(path_st_ini)
-    
-    # test 
-    testthat::expect_true(
-      "al_prefix" %in% names(read_ini))
-    testthat::expect_true(
-      "no_prefix" %in% names(read_ini))
-  })
+      cluster_name = "err",
+      opts = list(studyName="test",
+                  studyPath="C:/Users/beta/AppData/Local/Temp/RtmpQtOZyt/st-storage")), 
+    regexp = "opts does not inherit from class simOptions"
+  )
+})
+
+test_that("create cluster only for >=8.6",{
+  bad_opts <- simOptions()
+  bad_opts$antaresVersion <- 850
   
-  testthat::test_that("Cluster already exist?",{
+  expect_error(
     createClusterST(
       area = area_test_clust, 
-      cluster_name = "exist")
-    
-    testthat::expect_error(
+      cluster_name = "err",
+      opts = bad_opts), 
+    regexp = "only available if using Antares >= 8.6.0"
+  )
+})
+
+test_that("Check group",{
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      group = "myGroup"), 
+    regexp = "Group: 'myGroup' is not a valid name recognized by Antares"
+  )
+})
+
+test_that("Check area",{
+  expect_error(
+    createClusterST(
+      area = "area_test_clust", 
+      cluster_name = "err"), 
+    regexp = "'area_test_clust' is not a valid area name, possible names are: al"
+  )
+  test_that("no case sensitive",{
+    expect_no_error(
       createClusterST(
-        area = area_test_clust, 
-        cluster_name = "exist"), 
-      regexp = "al_exist already exist"
-    )
+        area = "AL", 
+        cluster_name = "case_sensitive"))
   })
-  
-  testthat::test_that("Overwrite working ?",{
+})
+
+test_that("Check input list 'storage_parameters'",{
+  # respect list format
+  expect_error(
     createClusterST(
       area = area_test_clust, 
-      cluster_name = "overwrite")
-    
-    testthat::expect_no_error(
-      createClusterST(
-        area = area_test_clust, 
-        cluster_name = "overwrite", 
-        overwrite = TRUE)
-    )
-  })
+      cluster_name = "err", 
+      storage_parameters = c(efficiency=1)), 
+    regexp = "storage_parameters does not inherit from class list"
+  )
   
-  testthat::test_that("New properties",{
-    testthat::test_that("Default values",{
-      # default call 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "default_prop")
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "default_prop",
-                                     sep = "_")]]
-      
-      # test default values
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        storage_values_default())
-    })
-    
-    testthat::test_that("Add right values",{
-      # only 2 params among all list
-      
-      # two way to write 
-      # 1- with all list
-      
-      # add new parameters 
-      all_params <- storage_values_default()
-      all_params[["efficiency"]] <- 0.9
-      all_params[["reservoircapacity"]] <- 1000
-      
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "two_new_properties", 
-                      storage_parameters = all_params)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "two_new_properties",
-                                     sep = "_")]]
-      
-      # test params created if identical with .ini read 
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        all_params)
-      
-      # 2- with list from sractch
-      my_list <- list(
-        efficiency = 0.9,
-        reservoircapacity = 1000
-      )
-      
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "two_new_properties_bis", 
-                      storage_parameters = my_list)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "two_new_properties_bis",
-                                     sep = "_")]]
-      
-      # test params created if identical with .ini read 
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        my_list)
-    })
-    
-    testthat::test_that("Overwrite properties",{
-      # default 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "overwrite_prop")
-      
-      # overwrite prop
-      all_params <- storage_values_default()
-      all_params[["efficiency"]] <- 0.9
-      all_params[["reservoircapacity"]] <- 1000
-      all_params[["initiallevel"]] <- 0.5
-      all_params[["withdrawalnominalcapacity"]] <- 250
-      all_params[["injectionnominalcapacity"]] <- 200
-      all_params[["initialleveloptim"]] <- TRUE
-      
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "overwrite_prop", 
-                      storage_parameters = all_params, 
-                      overwrite = TRUE)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "overwrite_prop",
-                                     sep = "_")]]
-      
-      # test params created if identical with .ini read 
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        all_params)
-    })
-  }) 
+  # list with formatted names
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiencyy=1)), 
+    regexp = "Parameter 'st-storage' must be named with the following elements: efficiency, reservoircapacity"
+  )
   
-  testthat::test_that("New TS values",{
-    # global var test
-    default_ts_values <- antaresEditObject:::.default_values_st_TS(opts = simOptions())
-    
-    original_files_names <- sapply(default_ts_values, 
-                                   function(x)x$string, 
-                                   USE.NAMES = FALSE)
-    
-    testthat::test_that("Default TS dim and values",{
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "default_ts")
-      
-      # read series 
-      opts_ <- simOptions()
-      path_ts <- file.path(opts_$inputPath, 
-                           "st-storage",
-                           "series",
-                           area_test_clust,
-                           "al_default_ts",
-                           paste0(original_files_names, 
-                                  ".txt"))
-      
-      files_series <- lapply(path_ts, 
-                             data.table::fread) 
-      
-      # test dim all equal
-      dim_files_series <- sapply(files_series, 
-                                 dim) 
-      testthat::expect_equal(mean(dim_files_series[1,]), 8760)
-      testthat::expect_equal(mean(dim_files_series[2,]), 1)
-      
-      # test all value equal to default values 
-      values_files_series <- sapply(files_series, 
-                                    sum)
-      sum_val <- (1*8760)+(1*8760)+0+0+(1*8760)
-      testthat::expect_equal(sum(values_files_series), sum_val)
-    })
-    
-    testthat::test_that("Add right TS values",{
-      good_ts <- matrix(0.7, 8760)
-      
-      # default with new optional TS
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "good_ts_value", 
-                      PMAX_injection = good_ts, 
-                      PMAX_withdrawal = good_ts, 
-                      inflows = good_ts, 
-                      lower_rule_curve = good_ts, 
-                      upper_rule_curve = good_ts)
-      
-      # read series 
-      opts_ <- simOptions()
-      path_ts <- file.path(opts_$inputPath, 
-                           "st-storage",
-                           "series",
-                           area_test_clust,
-                           "al_good_ts_value",
-                           paste0(original_files_names, 
-                                  ".txt"))
-      
-      files_series <- lapply(path_ts, 
-                             data.table::fread) 
-      
-      # test all value not equal to 0 (default)
-      values_files_series <- sapply(files_series, 
-                                    sum)
-      sum_val <- (0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)
-      testthat::expect_equal(sum(values_files_series),sum_val)
-    })
-  }) 
+  # check values parameters
+  # check is ratio ? 
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 2, 
+                                reservoircapacity = 100)), 
+    regexp = "efficiency must be in range 0-1"
+  )
   
-  #Delete study
-  deleteStudy()
+  # check positive capacity ? 
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 0.9, 
+                                reservoircapacity = -100)), 
+    regexp = "reservoircapacity must be >= 0"
+  )
+  
+  # check is logical ? 
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 0.9, 
+                                reservoircapacity = 100,
+                                initialleveloptim = "false")), 
+    regexp = 'list_values\\[\\[\\"initialleveloptim\\"\\]\\] does not inherit from class logical'
+  )
 })
 
 
-
-# >=880 ----
-
-testthat::test_that("New feature v8.8.0",{
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage880", 
-                antares_version = "8.8.0"))
+test_that("Check dimension TS input",{
+  # test col dim
+  bad_matrix_data_dim <- matrix(1, 8760*2, ncol = 2)
   
-  # default area with st cluster
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      PMAX_injection = bad_matrix_data_dim), 
+    regexp = "Input data for PMAX_injection must be 8760\\*1"
+  )
   
-  # default 
+  # test raw dim
+  bad_matrix_data_dim <- matrix(1, 8784)
+  
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      PMAX_injection = bad_matrix_data_dim), 
+    regexp = "Input data for PMAX_injection must be 8760\\*1"
+  )
+})
+
+test_that("Prefix is working?",{
+  # default with prefix
+  createClusterST(
+    area = area_test_clust, 
+    cluster_name = "prefix")
+  
+  # no prefix
+  createClusterST(
+    area = area_test_clust, 
+    cluster_name = "no_prefix", 
+    add_prefix = FALSE)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  
+  # test 
+  expect_true(
+    "al_prefix" %in% names(read_ini))
+  expect_true(
+    "no_prefix" %in% names(read_ini))
+})
+
+test_that("Cluster already exist?",{
+  createClusterST(
+    area = area_test_clust, 
+    cluster_name = "exist")
+  
+  expect_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "exist"), 
+    regexp = "al_exist already exist"
+  )
+  
+  test_that("no case sensitive",{
+    expect_error(
+      createClusterST(
+        area = area_test_clust, 
+        cluster_name = "ExiST"), 
+      regexp = "al_exist already exist"
+    )
+  })
+})
+
+test_that("Overwrite working ?",{
+createClusterST(
+    area = area_test_clust, 
+    cluster_name = "overwrite")
+  
+  expect_no_error(
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "overwrite", 
+      overwrite = TRUE)
+  )
+  
+  test_that("no case sensitive",{
+    expect_no_error(
+      createClusterST(
+        area = area_test_clust, 
+        cluster_name = "OverWRITE", 
+        overwrite = TRUE)
+    )
+  })
+})
+
+## New properties ----
+test_that("Default values",{
+  # default call 
   createClusterST(area = area_test_clust, 
-                  cluster_name = "default")
+                  cluster_name = "default_prop")
   
   # read prop
   path_st_ini <- file.path("input", 
@@ -415,264 +222,471 @@ testthat::test_that("New feature v8.8.0",{
   
   read_ini <- antaresRead::readIni(path_st_ini)
   target_prop <- read_ini[[paste(area_test_clust, 
-                                 "default",
+                                 "default_prop",
                                  sep = "_")]]
   
   # test default values
-  testthat::expect_equal(
+  expect_equal(
     target_prop[setdiff(names(target_prop), 
                         c("name", "group"))], 
     storage_values_default())
-  
-  deleteStudy()
 })
 
-# >=9.2 ---- 
-testthat::test_that("New features v9.2",{
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage9.2", 
-                antares_version = "9.2"))
+test_that("Add right values",{
+  # only 2 params among all list
   
-  # default area with st cluster
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
+  # two way to write 
+  # 1- with all list
   
+  # add new parameters 
+  all_params <- storage_values_default()
+  all_params[["efficiency"]] <- 0.9
+  all_params[["reservoircapacity"]] <- 1000
   
-  # TEST dynamic groups
-  testthat::test_that("Allow dynamic `group`",{
-    # default with group
-    createClusterST(area = area_test_clust, 
-                    cluster_name = "dynamic_grp", 
-                    group = "toto")
-    
-    # read properties
-    opts_ <- simOptions()
-    st_path <- file.path("input",
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "two_new_properties", 
+                  storage_parameters = all_params)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "two_new_properties",
+                                 sep = "_")]]
+  
+  # test params created if identical with .ini read 
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    all_params)
+  
+  # 2- with list from sractch
+  my_list <- list(
+    efficiency = 0.9,
+    reservoircapacity = 1000
+  )
+  
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "two_new_properties_bis", 
+                  storage_parameters = my_list)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "two_new_properties_bis",
+                                 sep = "_")]]
+  
+  # test params created if identical with .ini read 
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    my_list)
+})
+
+test_that("Overwrite properties",{
+  # default 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "overwrite_prop")
+  
+  # overwrite prop
+  all_params <- storage_values_default()
+  all_params[["efficiency"]] <- 0.9
+  all_params[["reservoircapacity"]] <- 1000
+  all_params[["initiallevel"]] <- 0.5
+  all_params[["withdrawalnominalcapacity"]] <- 250
+  all_params[["injectionnominalcapacity"]] <- 200
+  all_params[["initialleveloptim"]] <- TRUE
+  
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "overwrite_prop", 
+                  storage_parameters = all_params, 
+                  overwrite = TRUE)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "overwrite_prop",
+                                 sep = "_")]]
+  
+  # test params created if identical with .ini read 
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    all_params)
+})
+
+
+## New TS values ----
+# global var test
+default_ts_values <- antaresEditObject:::.default_values_st_TS(opts = simOptions())
+
+original_files_names <- sapply(default_ts_values, 
+                               function(x)x$string, 
+                               USE.NAMES = FALSE)
+
+test_that("Default TS dim and values",{
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "default_ts")
+  
+  # read series 
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_default_ts",
+                       paste0(original_files_names, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+  
+  # test dim all equal
+  dim_files_series <- sapply(files_series, 
+                             dim) 
+  expect_equal(mean(dim_files_series[1,]), 8760)
+  expect_equal(mean(dim_files_series[2,]), 1)
+  
+  # test all value equal to default values 
+  values_files_series <- sapply(files_series, 
+                                sum)
+  sum_val <- (1*8760)+(1*8760)+0+0+(1*8760)
+  expect_equal(sum(values_files_series), sum_val)
+})
+
+test_that("Add right TS values",{
+  good_ts <- matrix(0.7, 8760)
+  
+  # default with new optional TS
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "good_ts_value", 
+                  PMAX_injection = good_ts, 
+                  PMAX_withdrawal = good_ts, 
+                  inflows = good_ts, 
+                  lower_rule_curve = good_ts, 
+                  upper_rule_curve = good_ts)
+  
+  # read series 
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_good_ts_value",
+                       paste0(original_files_names, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+  
+  # test all value not equal to 0 (default)
+  values_files_series <- sapply(files_series, 
+                                sum)
+  sum_val <- (0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)
+  expect_equal(sum(values_files_series),sum_val)
+})
+
+
+#Delete study
+deleteStudy()
+
+
+
+# >=880 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage880", 
+              antares_version = "8.8.0"))
+
+# default area with st cluster
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+# default 
+createClusterST(area = area_test_clust, 
+                cluster_name = "default")
+
+# read prop
+path_st_ini <- file.path("input", 
                          "st-storage", 
                          "clusters", 
-                         area_test_clust, 
+                         area_test_clust,
                          "list")
-    
-    st_file <- readIni(pathIni = st_path)
-    
-    # group has no restrictions
-    testthat::expect_equal(st_file[[names(st_file)]][["group"]], 
-                           "toto")
-  })
+
+read_ini <- antaresRead::readIni(path_st_ini)
+target_prop <- read_ini[[paste(area_test_clust, 
+                               "default",
+                               sep = "_")]]
+
+# test default values
+expect_equal(
+  target_prop[setdiff(names(target_prop), 
+                      c("name", "group"))], 
+  storage_values_default())
+
+deleteStudy()
+
+
+# >=9.2 ---- 
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage9.2", 
+              antares_version = "9.2"))
+
+# default area with st cluster
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+
+# TEST dynamic groups
+test_that("Allow dynamic `group`",{
+  # default with group
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "dynamic_grp", 
+                  group = "toto")
   
+  # read properties
+  opts_ <- simOptions()
+  st_path <- file.path("input",
+                       "st-storage", 
+                       "clusters", 
+                       area_test_clust, 
+                       "list")
   
-  # ALL TEST about new properties 
-  testthat::test_that("New properties",{
-    testthat::test_that("Default values",{
-      
-      # default call 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "default_prop")
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "default_prop",
-                                     sep = "_")]]
-      
-      # test default values
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        storage_values_default())
-    })
-    
-    testthat::test_that("Wrong type/values",{
-      # add new parameters 
-      all_params <- storage_values_default()
-      
-      # "efficiencywithdrawal"
-      # type
-      all_params[["efficiencywithdrawal"]] <- TRUE
-      
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "err", 
-                        storage_parameters = all_params), 
-        regexp = "x does not inherit from class numeric"
-      )
-      
-      # value
-      all_params[["efficiencywithdrawal"]] <- 2.89
-      
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "err", 
-                        storage_parameters = all_params), 
-        regexp = "efficiencywithdrawal must be in range 0-1"
-      )
-     
-      
-      # "penalize-variation-injection"
-      all_params <- storage_values_default()
-      
-      # type
-      all_params[["penalize-variation-injection"]] <- 0.9
-      
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "err", 
-                        storage_parameters = all_params), 
-        regexp = "does not inherit from class logical"
-      )
-      
-      # NO TEST value (only TRUE/FALSE)
-   
-      
-      # "penalize-variation-withdrawal"
-      all_params <- storage_values_default()
-      
-      # type
-      all_params[["penalize-variation-withdrawal"]] <- "area"
-      
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "err", 
-                        storage_parameters = all_params), 
-        regexp = "does not inherit from class logical"
-      )
-      
-      # NO TEST value (only TRUE/FALSE)
-    })
-    
-    testthat::test_that("Add right values",{
-      # add new parameters 
-      all_params <- storage_values_default()
-      all_params[["efficiencywithdrawal"]] <- 0.9
-      all_params[["penalize-variation-injection"]] <- TRUE
-      all_params[["penalize-variation-withdrawal"]] <- TRUE
-      
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "new_properties", 
-                      storage_parameters = all_params)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "new_properties",
-                                     sep = "_")]]
-      
-      # test params created if identical with .ini read 
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        all_params)
-    })
-    
-  })
+  st_file <- readIni(pathIni = st_path)
   
-  # ALL TEST about TS values
-  testthat::test_that("New TS Values",{
-    # global var 
-    list_value_920 <- c("cost-injection", 
-                        "cost-withdrawal", 
-                        "cost-level", 
-                        "cost-variation-injection", 
-                        "cost-variation-withdrawal")
-  
-    testthat::test_that("Default TS dim and values",{
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "default_ts")
-      
-      # read series 
-      opts_ <- simOptions()
-      path_ts <- file.path(opts_$inputPath, 
-                           "st-storage",
-                           "series",
-                           area_test_clust,
-                           "al_default_ts",
-                           paste0(list_value_920, 
-                                  ".txt"))
-      
-      files_series <- lapply(path_ts, 
-                             data.table::fread) 
-      
-      # test dim all equal
-      dim_files_series <- sapply(files_series, 
-                                 dim) 
-      testthat::expect_equal(mean(dim_files_series[1,]), 8760)
-      testthat::expect_equal(mean(dim_files_series[2,]), 1)
-      
-      # test all value equal to 0 
-      values_files_series <- sapply(files_series, 
-                                    sum)
-      testthat::expect_equal(sum(values_files_series), 0)
-    })
-    
-    testthat::test_that("Wrong dim TS",{
-      # like 8.6, these TS are dim [8760;1]
-      bad_ts <- matrix(3, 8760*2, ncol = 2)
-      
-      # default with bad TS (just test 2 param)
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "wrong_ts_dim", 
-                        cost_injection = bad_ts), 
-        regexp = "Input data for cost_injection must be 8760\\*1"
-      )
-      testthat::expect_error(
-        createClusterST(area = area_test_clust, 
-                        cluster_name = "wrong_ts_dim", 
-                        cost_withdrawal = bad_ts), 
-        regexp = "Input data for cost_withdrawal must be 8760\\*1"
-      )
-    })
-    
-    testthat::test_that("Add right TS values",{
-      good_ts <- matrix(0.7, 8760)
-      
-      # default with new optional TS
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "good_ts_value", 
-                      cost_injection = good_ts, 
-                      cost_withdrawal = good_ts, 
-                      cost_level = good_ts, 
-                      cost_variation_injection = good_ts,
-                      cost_variation_withdrawal = good_ts)
-      
-      # read series 
-      opts_ <- simOptions()
-      path_ts <- file.path(opts_$inputPath, 
-                           "st-storage",
-                           "series",
-                           area_test_clust,
-                           "al_good_ts_value",
-                           paste0(list_value_920, 
-                                  ".txt"))
-      
-      files_series <- lapply(path_ts, 
-                             data.table::fread) 
-    
-      # test all value not equal to 0 (default)
-      values_files_series <- sapply(files_series, 
-                                    sum)
-      testthat::expect_true(sum(values_files_series)>0)
-    })
-    
-  })
-  
-  deleteStudy()
+  # group has no restrictions
+  expect_equal(st_file[[names(st_file)]][["group"]], 
+                         "toto")
 })
+  
+  
+## New properties ----
+test_that("Default values",{
+  # default call 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "default_prop")
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "default_prop",
+                                 sep = "_")]]
+  
+  # test default values
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    storage_values_default())
+})
+  
+test_that("Wrong type/values",{
+  # add new parameters 
+  all_params <- storage_values_default()
+  
+  # "efficiencywithdrawal"
+  # type
+  all_params[["efficiencywithdrawal"]] <- TRUE
+  
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "err", 
+                    storage_parameters = all_params), 
+    regexp = "x does not inherit from class numeric"
+  )
+  
+  # value
+  all_params[["efficiencywithdrawal"]] <- 2.89
+  
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "err", 
+                    storage_parameters = all_params), 
+    regexp = "efficiencywithdrawal must be in range 0-1"
+  )
+ 
+  
+  # "penalize-variation-injection"
+  all_params <- storage_values_default()
+  
+  # type
+  all_params[["penalize-variation-injection"]] <- 0.9
+  
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "err", 
+                    storage_parameters = all_params), 
+    regexp = "does not inherit from class logical"
+  )
+  
+  # NO TEST value (only TRUE/FALSE)
+
+  
+  # "penalize-variation-withdrawal"
+  all_params <- storage_values_default()
+  
+  # type
+  all_params[["penalize-variation-withdrawal"]] <- "area"
+  
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "err", 
+                    storage_parameters = all_params), 
+    regexp = "does not inherit from class logical"
+  )
+  
+  # NO TEST value (only TRUE/FALSE)
+})
+  
+test_that("Add right values",{
+  # add new parameters 
+  all_params <- storage_values_default()
+  all_params[["efficiencywithdrawal"]] <- 0.9
+  all_params[["penalize-variation-injection"]] <- TRUE
+  all_params[["penalize-variation-withdrawal"]] <- TRUE
+  
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "new_properties", 
+                  storage_parameters = all_params)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "new_properties",
+                                 sep = "_")]]
+  
+  # test params created if identical with .ini read 
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    all_params)
+})
+    
+
+## New TS Values ----
+# global var 
+list_value_920 <- c("cost-injection", 
+                    "cost-withdrawal", 
+                    "cost-level", 
+                    "cost-variation-injection", 
+                    "cost-variation-withdrawal")
+  
+test_that("Default TS dim and values",{
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "default_ts")
+  
+  # read series 
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_default_ts",
+                       paste0(list_value_920, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+  
+  # test dim all equal
+  dim_files_series <- sapply(files_series, 
+                             dim) 
+  expect_equal(mean(dim_files_series[1,]), 8760)
+  expect_equal(mean(dim_files_series[2,]), 1)
+  
+  # test all value equal to 0 
+  values_files_series <- sapply(files_series, 
+                                sum)
+  expect_equal(sum(values_files_series), 0)
+})
+    
+test_that("Wrong dim TS",{
+  # like 8.6, these TS are dim [8760;1]
+  bad_ts <- matrix(3, 8760*2, ncol = 2)
+  
+  # default with bad TS (just test 2 param)
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "wrong_ts_dim", 
+                    cost_injection = bad_ts), 
+    regexp = "Input data for cost_injection must be 8760\\*1"
+  )
+  expect_error(
+    createClusterST(area = area_test_clust, 
+                    cluster_name = "wrong_ts_dim", 
+                    cost_withdrawal = bad_ts), 
+    regexp = "Input data for cost_withdrawal must be 8760\\*1"
+  )
+})
+    
+test_that("Add right TS values",{
+  good_ts <- matrix(0.7, 8760)
+  
+  # default with new optional TS
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "good_ts_value", 
+                  cost_injection = good_ts, 
+                  cost_withdrawal = good_ts, 
+                  cost_level = good_ts, 
+                  cost_variation_injection = good_ts,
+                  cost_variation_withdrawal = good_ts)
+  
+  # read series 
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_good_ts_value",
+                       paste0(list_value_920, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+
+  # test all value not equal to 0 (default)
+  values_files_series <- sapply(files_series, 
+                                sum)
+  expect_true(sum(values_files_series)>0)
+})
+    
+  
+deleteStudy()
+
 
 
 

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -435,7 +435,7 @@ testthat::test_that("New features v9.2",{
                       cost_withdrawal = good_ts, 
                       cost_level = good_ts, 
                       cost_variation_injection = good_ts,
-                      cost_variation_withdrawal = good_ts,overwrite = TRUE)
+                      cost_variation_withdrawal = good_ts)
       
       # read series 
       list_value_920 <- list(

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -267,7 +267,7 @@ testthat::test_that("New features v9.2",{
                                      sep = "_")]]
       
       # test default values
-      testthat::expect_identical(
+      testthat::expect_equal(
         target_prop[setdiff(names(target_prop), 
                             c("name", "group"))], 
         storage_values_default())
@@ -356,7 +356,7 @@ testthat::test_that("New features v9.2",{
                                      sep = "_")]]
       
       # test params created if identical with .ini readed 
-      testthat::expect_identical(
+      testthat::expect_equal(
         target_prop[setdiff(names(target_prop), 
                             c("name", "group"))], 
         all_params)

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -246,7 +246,7 @@ testthat::test_that("New features v9.2",{
   })
   
   
-  # TEST new properties created well
+  # ALL TEST about new properties 
   testthat::test_that("New properties",{
     testthat::test_that("Default values",{
       
@@ -360,6 +360,110 @@ testthat::test_that("New features v9.2",{
         target_prop[setdiff(names(target_prop), 
                             c("name", "group"))], 
         all_params)
+    })
+    
+  })
+  
+  # ALL TEST about TS values
+  testthat::test_that("New TS Values",{
+    testthat::test_that("Default TS dim and values",{
+      # default with new parameters 
+      createClusterST(area = area_test_clust, 
+                      cluster_name = "default_ts")
+      
+      # read series 
+      list_value_920 <- list(
+        cost_injection = list(N=0, string = "cost-injection"),
+        cost_withdrawal = list(N=0, string = "cost-withdrawal"),
+        cost_level = list(N=0, string = "cost-level"),
+        cost_variation_injection = list(N=0, string = "cost-variation-injection"),
+        cost_variation_withdrawal = list(N=0, string = "cost-variation-withdrawal"))
+      
+      names_files <- unlist(lapply(list_value_920, 
+                            function(x)x[["string"]]), 
+                            use.names = FALSE)
+      opts_ <- simOptions()
+      path_ts <- file.path(opts_$inputPath, 
+                           "st-storage",
+                           "series",
+                           area_test_clust,
+                           "al_default_ts",
+                           paste0(names_files, 
+                                  ".txt"))
+      
+      files_series <- lapply(path_ts, 
+                             data.table::fread) 
+      
+      # test dim all equal
+      dim_files_series <- sapply(files_series, 
+                                 dim) 
+      testthat::expect_equal(mean(dim_files_series[1,]), 8760)
+      testthat::expect_equal(mean(dim_files_series[2,]), 1)
+      
+      # test all value equal to 0 
+      values_files_series <- sapply(files_series, 
+                                    sum)
+      testthat::expect_equal(sum(values_files_series), 0)
+    })
+    
+    testthat::test_that("Wrong dim TS",{
+      # like 8.6, these TS are dim [8760;1]
+      bad_ts <- matrix(3, 8760*2, ncol = 2)
+      
+      # default with bad TS (just test 2 param)
+      testthat::expect_error(
+        createClusterST(area = area_test_clust, 
+                        cluster_name = "wrong_ts_dim", 
+                        cost_injection = bad_ts), 
+        regexp = "Input data for cost_injection must be 8760\\*1"
+      )
+      testthat::expect_error(
+        createClusterST(area = area_test_clust, 
+                        cluster_name = "wrong_ts_dim", 
+                        cost_withdrawal = bad_ts), 
+        regexp = "Input data for cost_withdrawal must be 8760\\*1"
+      )
+    })
+    
+    testthat::test_that("Add right TS values",{
+      good_ts <- matrix(0.7, 8760)
+      
+      # default with new optional TS
+      createClusterST(area = area_test_clust, 
+                      cluster_name = "good_ts_value", 
+                      cost_injection = good_ts, 
+                      cost_withdrawal = good_ts, 
+                      cost_level = good_ts, 
+                      cost_variation_injection = good_ts,
+                      cost_variation_withdrawal = good_ts,overwrite = TRUE)
+      
+      # read series 
+      list_value_920 <- list(
+        cost_injection = list(N=0, string = "cost-injection"),
+        cost_withdrawal = list(N=0, string = "cost-withdrawal"),
+        cost_level = list(N=0, string = "cost-level"),
+        cost_variation_injection = list(N=0, string = "cost-variation-injection"),
+        cost_variation_withdrawal = list(N=0, string = "cost-variation-withdrawal"))
+      
+      names_files <- unlist(lapply(list_value_920, 
+                                   function(x)x[["string"]]), 
+                            use.names = FALSE)
+      opts_ <- simOptions()
+      path_ts <- file.path(opts_$inputPath, 
+                           "st-storage",
+                           "series",
+                           area_test_clust,
+                           "al_good_ts_value",
+                           paste0(names_files, 
+                                  ".txt"))
+      
+      files_series <- lapply(path_ts, 
+                             data.table::fread) 
+    
+      # test all value not equal to 0 (default)
+      values_files_series <- sapply(files_series, 
+                                    sum)
+      testthat::expect_true(sum(values_files_series)>0)
     })
     
   })

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -130,6 +130,34 @@ test_that("New feature v8.6",{
     )
   })
   
+  testthat::test_that("Prefix is working?",{
+    # default with prefix
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "prefix")
+    
+    # no prefix
+    createClusterST(
+      area = area_test_clust, 
+      cluster_name = "no_prefix", 
+      add_prefix = FALSE)
+    
+    # read prop
+    path_st_ini <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             area_test_clust,
+                             "list")
+    
+    read_ini <- antaresRead::readIni(path_st_ini)
+    
+    # test 
+    testthat::expect_true(
+      "al_prefix" %in% names(read_ini))
+    testthat::expect_true(
+      "no_prefix" %in% names(read_ini))
+  })
+  
   testthat::test_that("Cluster already exist?",{
     createClusterST(
       area = area_test_clust, 

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -1,523 +1,527 @@
 
-# v860 ----
-test_that("New feature v8.6", {
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage", 
-                antares_version = "8.6.0"))
-  
-  # just need at least one area
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
-  
-  # at least need 1 st cluster
-  createClusterST(area = area_test_clust, 
-                  cluster_name = "cluster_init")
-  
-  
-  testthat::test_that("study opts parameters",{
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "cluster_init",
-        opts = list(studyName="test",
-                    studyPath="C:/Users/beta/AppData/Local/Temp/RtmpQtOZyt/st-storage")), 
-      regexp = "opts does not inherit from class simOptions"
-    )
-  })
-  
-  testthat::test_that("create cluster only for >=8.6",{
-    bad_opts <- simOptions()
-    bad_opts$antaresVersion <- 850
-    
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err",
-        opts = bad_opts), 
-      regexp = "only available if using Antares >= 8.6.0"
-    )
-  })
-  
-  testthat::test_that("Check area",{
-    testthat::expect_error(
-      editClusterST(
-        area = "area_test_clust", 
-        cluster_name = "err"), 
-      regexp = "'area_test_clust' is not a valid area name, possible names are: al"
-    )
-  })
-  
-  testthat::test_that("Check group",{
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        group = "myGroup"), 
-      regexp = "Group: 'myGroup' is not a valid name recognized by Antares"
-    )
-  })
-  
-  testthat::test_that("Check input list 'storage_parameters'",{
-    # respect list format
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = c(efficiency=1)), 
-      regexp = "storage_parameters does not inherit from class list"
-    )
-    
-    # list with formatted names
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiencyy=1)), 
-      regexp = "Parameter 'st-storage' must be named with the following elements: efficiency, reservoircapacity"
-    )
-    
-    # check values parameters
-    # check is ratio ? 
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 2, 
-                                  reservoircapacity = 100)), 
-      regexp = "efficiency must be in range 0-1"
-    )
-    
-    # check positive capacity ? 
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 0.9, 
-                                  reservoircapacity = -100)), 
-      regexp = "reservoircapacity must be >= 0"
-    )
-    
-    # check is logical ? 
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        storage_parameters = list(efficiency = 0.9, 
-                                  reservoircapacity = 100,
-                                  initialleveloptim = "false")), 
-      regexp = 'list_values\\[\\[\\"initialleveloptim\\"\\]\\] does not inherit from class logical'
-    )
-  })
-  
-  testthat::test_that("Check dimension TS input",{
-    # test col dim
-    bad_matrix_data_dim <- matrix(1, 8760*2, ncol = 2)
-    
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        PMAX_injection = bad_matrix_data_dim), 
-      regexp = "Input data for PMAX_injection must be 8760\\*1"
-    )
-    
-    # test raw dim
-    bad_matrix_data_dim <- matrix(1, 8784)
-    
-    testthat::expect_error(
-      editClusterST(
-        area = area_test_clust, 
-        cluster_name = "err", 
-        PMAX_injection = bad_matrix_data_dim), 
-      regexp = "Input data for PMAX_injection must be 8760\\*1"
-    )
-  })
-  
-  testthat::test_that("Check existing cluster ?",{
-    testthat::expect_error(
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "casper", 
-                    group = "Other1"), 
-      regexp = "'al_casper' doesn't exist")
-  })
-  
-  testthat::test_that("Default call warning",{
-    # function can be called without modification
-    testthat::expect_warning(
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init"), 
-      regexp = "No edition for 'list.ini' file")
-  })
-  
-  testthat::test_that("Edit new properties",{
-    testthat::test_that("Edit group",{
-      # group list
-      st_storage_group <- c("PSP_open", 
-                            "PSP_closed", 
-                            "Pondage", 
-                            "Battery",
-                            paste0("Other", 
-                                   seq(1,5)))
-      
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init", 
-                    group = "Battery")
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "cluster_init",
-                                     sep = "_")]]
-      
-      # test params created if identical with .ini read 
-      testthat::expect_equal(target_prop[["group"]], 
-                             "Battery")
-    })
-    
-    testthat::test_that("Edit list of parameters 'storage_parameters'",{
-      # edit all params
-      all_params <- storage_values_default()
-      all_params[["efficiency"]] <- 0.9
-      all_params[["reservoircapacity"]] <- 1000
-      all_params[["initiallevel"]] <- 0.5
-      all_params[["withdrawalnominalcapacity"]] <- 250
-      all_params[["injectionnominalcapacity"]] <- 200
-      all_params[["initialleveloptim"]] <- TRUE
-      
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "cluster_init", 
-                    group = "Battery", 
-                    storage_parameters = all_params)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "cluster_init",
-                                     sep = "_")]]
-      
-      # test all properties from .ini
-      testthat::expect_equal(
-        target_prop[setdiff(names(target_prop), 
-                            c("name", "group"))], 
-        all_params)
-    })
-    
-  })
-  
-  testthat::test_that("Edit new TS values",{
-    # there are no test on values 
-    
-    # global var test
-    default_ts_values <- antaresEditObject:::.default_values_st_TS(opts = simOptions())
-    
-    original_files_names <- sapply(default_ts_values, 
-                                   function(x)x$string, 
-                                   USE.NAMES = FALSE)
-    
-    good_dim_ts <- matrix(0.7, 8760)
-    
-    # default with new optional TS
-    editClusterST(area = area_test_clust, 
-                  cluster_name = "cluster_init", 
-                  PMAX_injection = good_dim_ts, 
-                  PMAX_withdrawal = good_dim_ts, 
-                  inflows = good_dim_ts, 
-                  lower_rule_curve = good_dim_ts, 
-                  upper_rule_curve = good_dim_ts)
-    
-    # read series 
-    opts_ <- simOptions()
-    path_ts <- file.path(opts_$inputPath, 
-                         "st-storage",
-                         "series",
-                         area_test_clust,
-                         "al_cluster_init",
-                         paste0(original_files_names, 
-                                ".txt"))
-    
-    files_series <- lapply(path_ts, 
-                           data.table::fread) 
-    
-    # test all value not equal to 0 (default)
-    values_files_series <- sapply(files_series, 
-                                  sum)
-    sum_val <- (0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)
-    testthat::expect_equal(sum(values_files_series),sum_val)
-  })
-    
-  #Delete study
-  deleteStudy()
-})
+# >=v860 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage", 
+              antares_version = "8.6.0"))
+
+# just need at least one area
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+# at least need 1 st cluster
+createClusterST(area = area_test_clust, 
+                cluster_name = "cluster_init")
 
 
-# v880 ----
-test_that("New feature v8.8.0)",{
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage880", 
-                antares_version = "8.8.0"))
-  
-  # default area with st cluster
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
-  
-  # default 
-  createClusterST(area = area_test_clust, 
-                  cluster_name = "default")
-  
-  test_that("New parameter 'enabled'",{
-    # edit 
-    list_params <- storage_values_default()
-    list_params$efficiency <- 0.5
-    list_params$reservoircapacity <- 50
-    list_params$enabled <- FALSE
-    
-    editClusterST(area = area_test_clust, 
-                  cluster_name = "default", 
-                  storage_parameters = list_params)
-    
-    # read prop
-    path_st_ini <- file.path("input", 
-                             "st-storage", 
-                             "clusters", 
-                             area_test_clust,
-                             "list")
-    
-    read_ini <- antaresRead::readIni(path_st_ini)
-    target_prop <- read_ini[[paste(area_test_clust, 
-                                   "default",
-                                   sep = "_")]]
-    
-    # test all properties from .ini
-    testthat::expect_equal(
-      target_prop[setdiff(names(target_prop), 
-                          c("name", "group"))], 
-      list_params)
-  })
-  
-  deleteStudy()
+test_that("study opts parameters",{
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "cluster_init",
+      opts = list(studyName="test",
+                  studyPath="C:/Users/beta/AppData/Local/Temp/RtmpQtOZyt/st-storage")), 
+    regexp = "opts does not inherit from class simOptions"
+  )
 })
+
+test_that("create cluster only for >=8.6",{
+  bad_opts <- simOptions()
+  bad_opts$antaresVersion <- 850
+  
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err",
+      opts = bad_opts), 
+    regexp = "only available if using Antares >= 8.6.0"
+  )
+})
+
+test_that("Check area",{
+  expect_error(
+    editClusterST(
+      area = "area_test_clust", 
+      cluster_name = "err"), 
+    regexp = "'area_test_clust' is not a valid area name, possible names are: al"
+  )
+  test_that("no case sensitive",{
+    expect_no_error(
+      editClusterST(
+        area = "AL", 
+        group = "PSP_open",
+        cluster_name = "cluster_init"))
+  })
+})
+
+test_that("Check group",{
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      group = "myGroup"), 
+    regexp = "Group: 'myGroup' is not a valid name recognized by Antares"
+  )
+})
+
+test_that("Check input list 'storage_parameters'",{
+  # respect list format
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = c(efficiency=1)), 
+    regexp = "storage_parameters does not inherit from class list"
+  )
+  
+  # list with formatted names
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiencyy=1)), 
+    regexp = "Parameter 'st-storage' must be named with the following elements: efficiency, reservoircapacity"
+  )
+  
+  # check values parameters
+  # check is ratio ? 
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 2, 
+                                reservoircapacity = 100)), 
+    regexp = "efficiency must be in range 0-1"
+  )
+  
+  # check positive capacity ? 
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 0.9, 
+                                reservoircapacity = -100)), 
+    regexp = "reservoircapacity must be >= 0"
+  )
+  
+  # check is logical ? 
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      storage_parameters = list(efficiency = 0.9, 
+                                reservoircapacity = 100,
+                                initialleveloptim = "false")), 
+    regexp = 'list_values\\[\\[\\"initialleveloptim\\"\\]\\] does not inherit from class logical'
+  )
+})
+
+test_that("Check dimension TS input",{
+  # test col dim
+  bad_matrix_data_dim <- matrix(1, 8760*2, ncol = 2)
+  
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      PMAX_injection = bad_matrix_data_dim), 
+    regexp = "Input data for PMAX_injection must be 8760\\*1"
+  )
+  
+  # test raw dim
+  bad_matrix_data_dim <- matrix(1, 8784)
+  
+  expect_error(
+    editClusterST(
+      area = area_test_clust, 
+      cluster_name = "err", 
+      PMAX_injection = bad_matrix_data_dim), 
+    regexp = "Input data for PMAX_injection must be 8760\\*1"
+  )
+})
+
+test_that("Check existing cluster ?",{
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                  cluster_name = "casper", 
+                  group = "Other1"), 
+    regexp = "'al_casper' doesn't exist")
+  
+  test_that("no case sensitive",{
+    expect_no_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "Cluster_INIt",
+        group = "Other1"))
+  })
+})
+
+test_that("Default call warning",{
+  # function can be called without modification
+  expect_warning(
+    editClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init"), 
+    regexp = "No edition for 'list.ini' file")
+})
+
+## Edit new properties ----
+test_that("Edit group",{
+  # group list
+  st_storage_group <- c("PSP_open", 
+                        "PSP_closed", 
+                        "Pondage", 
+                        "Battery",
+                        paste0("Other", 
+                               seq(1,5)))
+  
+  editClusterST(area = area_test_clust, 
+                cluster_name = "cluster_init", 
+                group = "Battery")
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "cluster_init",
+                                 sep = "_")]]
+  
+  # test params created if identical with .ini read 
+  expect_equal(target_prop[["group"]], 
+                         "Battery")
+})
+
+test_that("Edit list of parameters 'storage_parameters'",{
+  # edit all params
+  all_params <- storage_values_default()
+  all_params[["efficiency"]] <- 0.9
+  all_params[["reservoircapacity"]] <- 1000
+  all_params[["initiallevel"]] <- 0.5
+  all_params[["withdrawalnominalcapacity"]] <- 250
+  all_params[["injectionnominalcapacity"]] <- 200
+  all_params[["initialleveloptim"]] <- TRUE
+  
+  editClusterST(area = area_test_clust, 
+                cluster_name = "cluster_init", 
+                group = "Battery", 
+                storage_parameters = all_params)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "cluster_init",
+                                 sep = "_")]]
+  
+  # test all properties from .ini
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    all_params)
+})
+  
+
+test_that("Edit new TS values",{
+  # there are no test on values 
+  
+  # global var test
+  default_ts_values <- antaresEditObject:::.default_values_st_TS(opts = simOptions())
+  
+  original_files_names <- sapply(default_ts_values, 
+                                 function(x)x$string, 
+                                 USE.NAMES = FALSE)
+  
+  good_dim_ts <- matrix(0.7, 8760)
+  
+  # default with new optional TS
+  editClusterST(area = area_test_clust, 
+                cluster_name = "cluster_init", 
+                PMAX_injection = good_dim_ts, 
+                PMAX_withdrawal = good_dim_ts, 
+                inflows = good_dim_ts, 
+                lower_rule_curve = good_dim_ts, 
+                upper_rule_curve = good_dim_ts)
+  
+  # read series 
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_cluster_init",
+                       paste0(original_files_names, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+  
+  # test all value not equal to 0 (default)
+  values_files_series <- sapply(files_series, 
+                                sum)
+  sum_val <- (0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)
+  expect_equal(sum(values_files_series),sum_val)
+})
+  
+#Delete study
+deleteStudy()
+
+
+# >=v880 ----
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage880", 
+              antares_version = "8.8.0"))
+
+# default area with st cluster
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+# default 
+createClusterST(area = area_test_clust, 
+                cluster_name = "default")
+
+test_that("New parameter 'enabled'",{
+  # edit 
+  list_params <- storage_values_default()
+  list_params$efficiency <- 0.5
+  list_params$reservoircapacity <- 50
+  list_params$enabled <- FALSE
+  
+  editClusterST(area = area_test_clust, 
+                cluster_name = "default", 
+                storage_parameters = list_params)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "default",
+                                 sep = "_")]]
+  
+  # test all properties from .ini
+  expect_equal(
+    target_prop[setdiff(names(target_prop), 
+                        c("name", "group"))], 
+    list_params)
+})
+
+deleteStudy()
 
 
 # >=9.2 ---- 
-testthat::test_that("New features v9.2",{
-  suppressWarnings(
-    createStudy(path = tempdir(), 
-                study_name = "st-storage9.2", 
-                antares_version = "9.2"))
-  
-  # default area with st cluster
-  area_test_clust = "al" 
-  createArea(name = area_test_clust)
-  
-  
-  # dynamic groups
-  testthat::test_that("Allow dynamic `group`",{
-    # create 
-    createClusterST(area = area_test_clust, 
-                    cluster_name = "dynamic_grp", 
-                    group = "toto")
-    
-    # edit
-    editClusterST(area = area_test_clust, 
+suppressWarnings(
+  createStudy(path = tempdir(), 
+              study_name = "st-storage9.2", 
+              antares_version = "9.2"))
+
+# default area with st cluster
+area_test_clust = "al" 
+createArea(name = area_test_clust)
+
+
+# dynamic groups
+test_that("Allow dynamic `group`",{
+  # create 
+  createClusterST(area = area_test_clust, 
                   cluster_name = "dynamic_grp", 
-                  group = "titi")
-    
-    # read properties
-    opts_ <- simOptions()
-    st_path <- file.path("input",
-                         "st-storage", 
-                         "clusters", 
-                         area_test_clust, 
-                         "list")
-    
-    st_file <- readIni(pathIni = st_path)
-    
-    # group has no restrictions
-    testthat::expect_equal(st_file[[names(st_file)]][["group"]], "titi")
-  })
+                  group = "toto")
   
-  testthat::test_that("Edit new properties",{
-    # wrong type/values not eccepted
-    testthat::test_that("Wrong type/values",{
-      
-      # "efficiencywithdrawal" with bad type
-      # type
-      edit_params <- list("efficiencywithdrawal" = TRUE)
-      
-      # create default
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "edit_wrong_prop")
-      
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_prop", 
-                        storage_parameters = edit_params), 
-        regexp = "x does not inherit from class numeric"
-      )
-      
-      # value
-      edit_params <- list("efficiencywithdrawal" = 2.89)
-      
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_prop", 
-                        storage_parameters = edit_params), 
-        regexp = "efficiencywithdrawal must be in range 0-1"
-      )
-      
-      # "penalize-variation-injection"
-      # type
-      edit_params <- list("penalize-variation-injection" = 0.9)
-      
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_prop", 
-                        storage_parameters = edit_params), 
-        regexp = "does not inherit from class logical"
-      )
-      
-      # NO TEST value (only TRUE/FALSE)
-      
-      
-      # "penalize-variation-withdrawal"
-      all_params <- storage_values_default()
-      
-      # type
-      edit_params <- list("penalize-variation-withdrawal" = "area")
-      
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_prop", 
-                        storage_parameters = edit_params), 
-        regexp = "does not inherit from class logical"
-      )
-      
-      # NO TEST value (only TRUE/FALSE)
-    })
-    
-    # edit new properties
-    testthat::test_that("Edit right values",{
-      # add new parameters 
-      all_params <- list(
-        "efficiencywithdrawal" = 0.9,
-        `penalize-variation-injection` = TRUE,
-        `penalize-variation-withdrawal` = TRUE
-      )
-      
-      # default with new parameters 
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "new_properties")
-      
-      # Edit with new parameters 
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "new_properties", 
-                    storage_parameters = all_params)
-      
-      # read prop
-      path_st_ini <- file.path("input", 
-                               "st-storage", 
-                               "clusters", 
-                               area_test_clust,
-                               "list")
-      
-      read_ini <- antaresRead::readIni(path_st_ini)
-      target_prop <- read_ini[[paste(area_test_clust, 
-                                     "new_properties",
-                                     sep = "_")]]
-      
-      # test params created if equal with .ini read 
-      testthat::expect_equal(
-        target_prop[names(all_params)], 
-        all_params)
-    })
-  })
+  # edit
+  editClusterST(area = area_test_clust, 
+                cluster_name = "dynamic_grp", 
+                group = "titi")
   
+  # read properties
+  opts_ <- simOptions()
+  st_path <- file.path("input",
+                       "st-storage", 
+                       "clusters", 
+                       area_test_clust, 
+                       "list")
   
+  st_file <- readIni(pathIni = st_path)
   
-  # ALL TEST about TS values
-  testthat::test_that("New TS Values",{
-    
-    testthat::test_that("Wrong dim TS",{
-      # like 8.6, these TS are dim [8760;1]
-      bad_ts <- matrix(3, 8760*2, ncol = 2)
-      
-      # create default
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "edit_wrong_ts")
-      
-      # default with bad TS (just test 2 param)
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_ts", 
-                        cost_injection = bad_ts), 
-        regexp = "Input data for cost_injection must be 8760\\*1"
-      )
-      testthat::expect_error(
-        editClusterST(area = area_test_clust, 
-                        cluster_name = "edit_wrong_ts", 
-                        cost_withdrawal = bad_ts), 
-        regexp = "Input data for cost_withdrawal must be 8760\\*1"
-      )
-    })
-    
-    testthat::test_that("Add right TS values",{
-      good_ts <- matrix(0.7, 8760)
-      
-      # default with new optional TS
-      createClusterST(area = area_test_clust, 
-                      cluster_name = "edit_good_ts_value")
-      
-      # edit with good values (only new TS)
-      editClusterST(area = area_test_clust, 
-                    cluster_name = "edit_good_ts_value", 
-                    cost_injection = good_ts, 
-                    cost_withdrawal = good_ts, 
-                    cost_level = good_ts, 
-                    cost_variation_injection = good_ts,
-                    cost_variation_withdrawal = good_ts)
-      
-      # read series 
-      names_files <- c("cost-injection",
-                       "cost-withdrawal",
-                       "cost-level",
-                       "cost-variation-injection",
-                       "cost-variation-withdrawal")
-      opts_ <- simOptions()
-      path_ts <- file.path(opts_$inputPath, 
-                           "st-storage",
-                           "series",
-                           area_test_clust,
-                           "al_edit_good_ts_value",
-                           paste0(names_files, 
-                                  ".txt"))
-      
-      files_series <- lapply(path_ts, 
-                             data.table::fread) 
-      
-      # test all value not equal to 0 (default)
-      values_files_series <- sapply(files_series, 
-                                    sum)
-      testthat::expect_true(sum(values_files_series)>0)
-    })
-  })
-  
-  
-  deleteStudy()
+  # group has no restrictions
+  expect_equal(st_file[[names(st_file)]][["group"]], "titi")
 })
+
+## Edit new properties ----
+# wrong type/values not eccepted
+test_that("Wrong type/values",{
+  
+  # "efficiencywithdrawal" with bad type
+  # type
+  edit_params <- list("efficiencywithdrawal" = TRUE)
+  
+  # create default
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "edit_wrong_prop")
+  
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_prop", 
+                    storage_parameters = edit_params), 
+    regexp = "x does not inherit from class numeric"
+  )
+  
+  # value
+  edit_params <- list("efficiencywithdrawal" = 2.89)
+  
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_prop", 
+                    storage_parameters = edit_params), 
+    regexp = "efficiencywithdrawal must be in range 0-1"
+  )
+  
+  # "penalize-variation-injection"
+  # type
+  edit_params <- list("penalize-variation-injection" = 0.9)
+  
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_prop", 
+                    storage_parameters = edit_params), 
+    regexp = "does not inherit from class logical"
+  )
+  
+  # NO TEST value (only TRUE/FALSE)
+  
+  
+  # "penalize-variation-withdrawal"
+  all_params <- storage_values_default()
+  
+  # type
+  edit_params <- list("penalize-variation-withdrawal" = "area")
+  
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_prop", 
+                    storage_parameters = edit_params), 
+    regexp = "does not inherit from class logical"
+  )
+  
+  # NO TEST value (only TRUE/FALSE)
+})
+
+# edit new properties
+test_that("Edit right values",{
+  # add new parameters 
+  all_params <- list(
+    "efficiencywithdrawal" = 0.9,
+    `penalize-variation-injection` = TRUE,
+    `penalize-variation-withdrawal` = TRUE
+  )
+  
+  # default with new parameters 
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "new_properties")
+  
+  # Edit with new parameters 
+  editClusterST(area = area_test_clust, 
+                cluster_name = "new_properties", 
+                storage_parameters = all_params)
+  
+  # read prop
+  path_st_ini <- file.path("input", 
+                           "st-storage", 
+                           "clusters", 
+                           area_test_clust,
+                           "list")
+  
+  read_ini <- antaresRead::readIni(path_st_ini)
+  target_prop <- read_ini[[paste(area_test_clust, 
+                                 "new_properties",
+                                 sep = "_")]]
+  
+  # test params created if equal with .ini read 
+  expect_equal(
+    target_prop[names(all_params)], 
+    all_params)
+})
+
+
+
+## New TS Values ----
+test_that("Wrong dim TS",{
+  # like 8.6, these TS are dim [8760;1]
+  bad_ts <- matrix(3, 8760*2, ncol = 2)
+  
+  # create default
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "edit_wrong_ts")
+  
+  # default with bad TS (just test 2 param)
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_ts", 
+                    cost_injection = bad_ts), 
+    regexp = "Input data for cost_injection must be 8760\\*1"
+  )
+  expect_error(
+    editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_wrong_ts", 
+                    cost_withdrawal = bad_ts), 
+    regexp = "Input data for cost_withdrawal must be 8760\\*1"
+  )
+})
+
+test_that("Add right TS values",{
+  good_ts <- matrix(0.7, 8760)
+  
+  # default with new optional TS
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "edit_good_ts_value")
+  
+  # edit with good values (only new TS)
+  editClusterST(area = area_test_clust, 
+                cluster_name = "edit_good_ts_value", 
+                cost_injection = good_ts, 
+                cost_withdrawal = good_ts, 
+                cost_level = good_ts, 
+                cost_variation_injection = good_ts,
+                cost_variation_withdrawal = good_ts)
+  
+  # read series 
+  names_files <- c("cost-injection",
+                   "cost-withdrawal",
+                   "cost-level",
+                   "cost-variation-injection",
+                   "cost-variation-withdrawal")
+  opts_ <- simOptions()
+  path_ts <- file.path(opts_$inputPath, 
+                       "st-storage",
+                       "series",
+                       area_test_clust,
+                       "al_edit_good_ts_value",
+                       paste0(names_files, 
+                              ".txt"))
+  
+  files_series <- lapply(path_ts, 
+                         data.table::fread) 
+  
+  # test all value not equal to 0 (default)
+  values_files_series <- sapply(files_series, 
+                                sum)
+  expect_true(sum(values_files_series)>0)
+})
+
+deleteStudy()
+
   
 
 

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -1,158 +1,270 @@
 
 # v860 ----
-test_that("edit st-storage clusters (only for study >= v8.6.0" , {
-  # global params for structure v8.6 ----
-  opts_test <-createStudy(path = tempdir(), 
-              study_name = "edit-cluster-st", 
-              antares_version = "8.6.0")
-  area_test = "be"
-  opts_test <- createArea(name = area_test, opts = opts_test)
-
-  ## 
-  # INIT : create tests clusters
-  ##
-  opts_test <- createClusterST(area_test, 
-                  "cluster-st-1", 
-                  opts = opts_test) 
+test_that("New feature v8.6", {
+  suppressWarnings(
+    createStudy(path = tempdir(), 
+                study_name = "st-storage", 
+                antares_version = "8.6.0"))
   
-  opts_test <- createClusterST(area_test, 
-                  "cluster-st-2", 
-                  opts = opts_test) 
+  # just need at least one area
+  area_test_clust = "al" 
+  createArea(name = area_test_clust)
   
-  st_clusters <- readClusterSTDesc(opts = opts_test)
-  
-  ## basics errors cases ----
-  testthat::expect_error(editClusterST(area = area_test, 
-                                       cluster_name = "cluster-st-1", 
-                                       opts = "toto"), 
-                         regexp = "inherit from class simOptions")
-  opts_fake <- opts_test
-  opts_fake$antaresVersion <- 820
-  testthat::expect_error(editClusterST(area = area_test, 
-                                       cluster_name = "cluster-st-1", 
-                                       opts = opts_fake), 
-                         regexp = "only available if using Antares >= 8.6.0")
-  testthat::expect_error(editClusterST(area = "area_test", 
-                                       cluster_name = "cluster-st-1", 
-                                       opts = opts_test), 
-                         regexp = "is not a valid area name")
-  testthat::expect_error(editClusterST(area = area_test, 
-                                       cluster_name = levels(st_clusters$cluster)[1], 
-                                       group = "new group", 
-                                       add_prefix = FALSE, 
-                                       opts = opts_test), 
-                         regexp = "is not a valid name recognized by Antares")
-  testthat::expect_error(editClusterST(area = area_test, 
-                                       cluster_name = "casper", 
-                                       group = "Other1",
-                                       add_prefix = FALSE, 
-                                       opts = opts_test), 
-                         regexp = "'casper' doesn't exist")
-  
-  ## default edition cluster ----
-    # if all parameters are NULL => no edition of ini and data .txt
-  testthat::expect_warning(editClusterST(area = area_test, 
-                                         cluster_name = levels(st_clusters$cluster)[1],
-                                         add_prefix = FALSE,
-                                         opts = opts_test), 
-                           regexp = "No edition for 'list.ini' file")
-  
-  ## edit list ini ----
-    # edit only group value
-  name_cluster_test <- levels(st_clusters$cluster)[1]
-  # case insensitive
-  expect_no_error(editClusterST(area = toupper(area_test),
-                                cluster_name = toupper(name_cluster_test),
-                                group = "Other5",
-                                add_prefix = FALSE,
-                                storage_parameters = list("efficiency" = 0.789),
-                                opts = opts_test))
-
-  opts_test <- editClusterST(area = area_test, 
-                             cluster_name = name_cluster_test,
-                             group = "Other2", 
-                             add_prefix = FALSE,
-                             opts = opts_test)
-  
-    # check update "group"
-  st_clusters <- readClusterSTDesc(opts = opts_test)
-  group_test <- st_clusters[cluster %in% name_cluster_test, 
-                            .SD, .SDcols= "group"]
-  testthat::expect_equal("Other2", as.character(group_test$group))
-
+  # at least need 1 st cluster
+  createClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init")
   
   
-    # edit values (only 2 parameters)
-  name_cluster_test <- levels(st_clusters$cluster)[2]
-  list_params <- storage_values_default()[1:2]
-  list_params$efficiency <- 0.5
-  list_params$reservoircapacity <- 50
+  testthat::test_that("study opts parameters",{
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "cluster_init",
+        opts = list(studyName="test",
+                    studyPath="C:/Users/beta/AppData/Local/Temp/RtmpQtOZyt/st-storage")), 
+      regexp = "opts does not inherit from class simOptions"
+    )
+  })
   
-  initial_values <- st_clusters[cluster %in% name_cluster_test, 
-                                .SD, 
-                                .SDcols= c("efficiency", "reservoircapacity")]
+  testthat::test_that("create cluster only for >=8.6",{
+    bad_opts <- simOptions()
+    bad_opts$antaresVersion <- 850
+    
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err",
+        opts = bad_opts), 
+      regexp = "only available if using Antares >= 8.6.0"
+    )
+  })
   
-  opts_test <- editClusterST(area = area_test, 
-                             cluster_name = name_cluster_test, 
-                             storage_parameters = list_params,
-                             opts = opts_test, 
-                             add_prefix = FALSE)
+  testthat::test_that("Check area",{
+    testthat::expect_error(
+      editClusterST(
+        area = "area_test_clust", 
+        cluster_name = "err"), 
+      regexp = "'area_test_clust' is not a valid area name, possible names are: al"
+    )
+  })
   
+  testthat::test_that("Check group",{
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        group = "myGroup"), 
+      regexp = "Group: 'myGroup' is not a valid name recognized by Antares"
+    )
+  })
   
-  st_clusters <- readClusterSTDesc(opts = opts_test)
-  value_to_test <- st_clusters[cluster %in% name_cluster_test, 
-                               .SD, 
-                               .SDcols= c("group", 
-                                          "efficiency", 
-                                          "reservoircapacity")]
+  testthat::test_that("Check input list 'storage_parameters'",{
+    # respect list format
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        storage_parameters = c(efficiency=1)), 
+      regexp = "storage_parameters does not inherit from class list"
+    )
+    
+    # list with formatted names
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        storage_parameters = list(efficiencyy=1)), 
+      regexp = "Parameter 'st-storage' must be named with the following elements: efficiency, reservoircapacity"
+    )
+    
+    # check values parameters
+    # check is ratio ? 
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        storage_parameters = list(efficiency = 2, 
+                                  reservoircapacity = 100)), 
+      regexp = "efficiency must be in range 0-1"
+    )
+    
+    # check positive capacity ? 
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        storage_parameters = list(efficiency = 0.9, 
+                                  reservoircapacity = -100)), 
+      regexp = "reservoircapacity must be >= 0"
+    )
+    
+    # check is logical ? 
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        storage_parameters = list(efficiency = 0.9, 
+                                  reservoircapacity = 100,
+                                  initialleveloptim = "false")), 
+      regexp = 'list_values\\[\\[\\"initialleveloptim\\"\\]\\] does not inherit from class logical'
+    )
+  })
   
-  # test value group is default
-  testthat::expect_equal("Other1", as.character(value_to_test$group))
+  testthat::test_that("Check dimension TS input",{
+    # test col dim
+    bad_matrix_data_dim <- matrix(1, 8760*2, ncol = 2)
+    
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        PMAX_injection = bad_matrix_data_dim), 
+      regexp = "Input data for PMAX_injection must be 8760\\*1"
+    )
+    
+    # test raw dim
+    bad_matrix_data_dim <- matrix(1, 8784)
+    
+    testthat::expect_error(
+      editClusterST(
+        area = area_test_clust, 
+        cluster_name = "err", 
+        PMAX_injection = bad_matrix_data_dim), 
+      regexp = "Input data for PMAX_injection must be 8760\\*1"
+    )
+  })
   
-  # test parameters are updated
-  value_to_test <- as.list(value_to_test[, .SD, 
-                                         .SDcols= c("efficiency", 
-                                                    "reservoircapacity")])
-  testthat::expect_equal(list_params, value_to_test)
+  testthat::test_that("Check existing cluster ?",{
+    testthat::expect_error(
+      editClusterST(area = area_test_clust, 
+                    cluster_name = "casper", 
+                    group = "Other1"), 
+      regexp = "'al_casper' doesn't exist")
+  })
   
- 
-  ## edit DATA ----
-  val <- 0.007
-  opts_test <- editClusterST(area = area_test, 
-                             cluster_name = levels(st_clusters$cluster)[1],  
-                             PMAX_injection = matrix(val, 8760), 
-                             PMAX_withdrawal = matrix(val, 8760),
-                             inflows =  matrix(0.007, 8760), 
-                             lower_rule_curve = matrix(val, 8760), 
-                             upper_rule_curve = matrix(val, 8760),
-                             opts = opts_test, 
-                             add_prefix = FALSE)
+  testthat::test_that("Default call warning",{
+    # function can be called without modification
+    testthat::expect_warning(
+      editClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init"), 
+      regexp = "No edition for 'list.ini' file")
+  })
   
-  # test data value (with fread_antares)
-  path_dir_test <- file.path(opts_test$inputPath, "st-storage", "series", area_test, 
-                             paste(area_test, "cluster-st-1", sep = "_"))
-  files_test <- list.files(path_dir_test, full.names = TRUE)
-  l_file_series <- lapply(files_test, antaresRead:::fread_antares, opts = opts_test)
+  testthat::test_that("Edit new properties",{
+    testthat::test_that("Edit group",{
+      # group list
+      st_storage_group <- c("PSP_open", 
+                            "PSP_closed", 
+                            "Pondage", 
+                            "Battery",
+                            paste0("Other", 
+                                   seq(1,5)))
+      
+      editClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init", 
+                    group = "Battery")
+      
+      # read prop
+      path_st_ini <- file.path("input", 
+                               "st-storage", 
+                               "clusters", 
+                               area_test_clust,
+                               "list")
+      
+      read_ini <- antaresRead::readIni(path_st_ini)
+      target_prop <- read_ini[[paste(area_test_clust, 
+                                     "cluster_init",
+                                     sep = "_")]]
+      
+      # test params created if identical with .ini read 
+      testthat::expect_equal(target_prop[["group"]], 
+                             "Battery")
+    })
+    
+    testthat::test_that("Edit list of parameters 'storage_parameters'",{
+      # edit all params
+      all_params <- storage_values_default()
+      all_params[["efficiency"]] <- 0.9
+      all_params[["reservoircapacity"]] <- 1000
+      all_params[["initiallevel"]] <- 0.5
+      all_params[["withdrawalnominalcapacity"]] <- 250
+      all_params[["injectionnominalcapacity"]] <- 200
+      all_params[["initialleveloptim"]] <- TRUE
+      
+      editClusterST(area = area_test_clust, 
+                    cluster_name = "cluster_init", 
+                    group = "Battery", 
+                    storage_parameters = all_params)
+      
+      # read prop
+      path_st_ini <- file.path("input", 
+                               "st-storage", 
+                               "clusters", 
+                               area_test_clust,
+                               "list")
+      
+      read_ini <- antaresRead::readIni(path_st_ini)
+      target_prop <- read_ini[[paste(area_test_clust, 
+                                     "cluster_init",
+                                     sep = "_")]]
+      
+      # test all properties from .ini
+      testthat::expect_equal(
+        target_prop[setdiff(names(target_prop), 
+                            c("name", "group"))], 
+        all_params)
+    })
+    
+  })
   
-  value_test <- mean(sapply(l_file_series, 
-                       function(.x){
-                         mean(.x$V1)}))
-  
-  testthat::expect_equal(value_test, val)
-  
-  # test data value with readInputTS
-  st_ts <- readInputTS(st_storage = "all", opts = opts_test)
-  
-  # check clusters
-  testthat::expect_true(all(levels(st_clusters$cluster) %in% unique(st_ts$cluster)))
-  
-  # delete study
-  unlink(opts_test$studyPath, recursive = TRUE)
+  testthat::test_that("Edit new TS values",{
+    # there are no test on values 
+    
+    # global var test
+    default_ts_values <- antaresEditObject:::.default_values_st_TS(opts = simOptions())
+    
+    original_files_names <- sapply(default_ts_values, 
+                                   function(x)x$string, 
+                                   USE.NAMES = FALSE)
+    
+    good_dim_ts <- matrix(0.7, 8760)
+    
+    # default with new optional TS
+    editClusterST(area = area_test_clust, 
+                  cluster_name = "cluster_init", 
+                  PMAX_injection = good_dim_ts, 
+                  PMAX_withdrawal = good_dim_ts, 
+                  inflows = good_dim_ts, 
+                  lower_rule_curve = good_dim_ts, 
+                  upper_rule_curve = good_dim_ts)
+    
+    # read series 
+    opts_ <- simOptions()
+    path_ts <- file.path(opts_$inputPath, 
+                         "st-storage",
+                         "series",
+                         area_test_clust,
+                         "al_cluster_init",
+                         paste0(original_files_names, 
+                                ".txt"))
+    
+    files_series <- lapply(path_ts, 
+                           data.table::fread) 
+    
+    # test all value not equal to 0 (default)
+    values_files_series <- sapply(files_series, 
+                                  sum)
+    sum_val <- (0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)+(0.7*8760)
+    testthat::expect_equal(sum(values_files_series),sum_val)
+  })
+    
+  #Delete study
+  deleteStudy()
 })
 
+
 # v880 ----
-test_that("Edit short-term storage cluster (new feature v8.8.0)",{
-  ## basics errors cases ----
+test_that("New feature v8.8.0)",{
   suppressWarnings(
     createStudy(path = tempdir(), 
                 study_name = "st-storage880", 
@@ -166,34 +278,34 @@ test_that("Edit short-term storage cluster (new feature v8.8.0)",{
   createClusterST(area = area_test_clust, 
                   cluster_name = "default")
   
-  # edit 
-  list_params <- storage_values_default()
-  list_params$efficiency <- 0.5
-  list_params$reservoircapacity <- 50
-  list_params$enabled <- FALSE
-  
-  editClusterST(area = area_test_clust, 
-                cluster_name = "default", 
-                storage_parameters = list_params)
-  
-  # read properties 
-  st_params <- readClusterSTDesc()
-  
-  # "enabled" must be present 
-  testthat::expect_true("enabled"%in%names(st_params))
-  testthat::expect_true(st_params$enabled[1]%in%FALSE)
-  
-  # test restrictions on 'group' parameter
-  testthat::test_that("static 'group",{
-    testthat::expect_error(
-      editClusterST(area = area_test_clust, 
-                      cluster_name = "default", 
-                      group = "not_allowed"), 
-      regexp = paste0(
-        "Group: '", "not_allowed", "' is not a valid name recognized by Antares,"
-      )
-    )
+  test_that("New parameter 'enabled'",{
+    # edit 
+    list_params <- storage_values_default()
+    list_params$efficiency <- 0.5
+    list_params$reservoircapacity <- 50
+    list_params$enabled <- FALSE
     
+    editClusterST(area = area_test_clust, 
+                  cluster_name = "default", 
+                  storage_parameters = list_params)
+    
+    # read prop
+    path_st_ini <- file.path("input", 
+                             "st-storage", 
+                             "clusters", 
+                             area_test_clust,
+                             "list")
+    
+    read_ini <- antaresRead::readIni(path_st_ini)
+    target_prop <- read_ini[[paste(area_test_clust, 
+                                   "default",
+                                   sep = "_")]]
+    
+    # test all properties from .ini
+    testthat::expect_equal(
+      target_prop[setdiff(names(target_prop), 
+                          c("name", "group"))], 
+      list_params)
   })
   
   deleteStudy()

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -339,6 +339,68 @@ testthat::test_that("New features v9.2",{
   # ALL TEST about TS values
   testthat::test_that("New TS Values",{
     
+    testthat::test_that("Wrong dim TS",{
+      # like 8.6, these TS are dim [8760;1]
+      bad_ts <- matrix(3, 8760*2, ncol = 2)
+      
+      # create default
+      createClusterST(area = area_test_clust, 
+                      cluster_name = "edit_wrong_ts")
+      
+      # default with bad TS (just test 2 param)
+      testthat::expect_error(
+        editClusterST(area = area_test_clust, 
+                        cluster_name = "edit_wrong_ts", 
+                        cost_injection = bad_ts), 
+        regexp = "Input data for cost_injection must be 8760\\*1"
+      )
+      testthat::expect_error(
+        editClusterST(area = area_test_clust, 
+                        cluster_name = "edit_wrong_ts", 
+                        cost_withdrawal = bad_ts), 
+        regexp = "Input data for cost_withdrawal must be 8760\\*1"
+      )
+    })
+    
+    testthat::test_that("Add right TS values",{
+      good_ts <- matrix(0.7, 8760)
+      
+      # default with new optional TS
+      createClusterST(area = area_test_clust, 
+                      cluster_name = "edit_good_ts_value")
+      
+      # edit with good values (only new TS)
+      editClusterST(area = area_test_clust, 
+                    cluster_name = "edit_good_ts_value", 
+                    cost_injection = good_ts, 
+                    cost_withdrawal = good_ts, 
+                    cost_level = good_ts, 
+                    cost_variation_injection = good_ts,
+                    cost_variation_withdrawal = good_ts)
+      
+      # read series 
+      names_files <- c("cost-injection",
+                       "cost-withdrawal",
+                       "cost-level",
+                       "cost-variation-injection",
+                       "cost-variation-withdrawal")
+      opts_ <- simOptions()
+      path_ts <- file.path(opts_$inputPath, 
+                           "st-storage",
+                           "series",
+                           area_test_clust,
+                           "al_edit_good_ts_value",
+                           paste0(names_files, 
+                                  ".txt"))
+      
+      files_series <- lapply(path_ts, 
+                             data.table::fread) 
+      
+      # test all value not equal to 0 (default)
+      values_files_series <- sapply(files_series, 
+                                    sum)
+      testthat::expect_true(sum(values_files_series)>0)
+    })
   })
   
   

--- a/tests/testthat/test-editClusterST.R
+++ b/tests/testthat/test-editClusterST.R
@@ -327,7 +327,7 @@ testthat::test_that("New features v9.2",{
                                      "new_properties",
                                      sep = "_")]]
       
-      # test params created if equal with .ini readed 
+      # test params created if equal with .ini read 
       testthat::expect_equal(
         target_prop[names(all_params)], 
         all_params)

--- a/vignettes/Antares_new_features_v920.Rmd
+++ b/vignettes/Antares_new_features_v920.Rmd
@@ -63,11 +63,13 @@ We can create new clusters, st-storage (from v8.6), with function `createCluster
 
 By default you can call function only with two parameters (`area`, `cluster_name`). 
 
-### No restriction on group names
+Clusters are created with default properties and time series.
+
+### Dynamic group names
 
 Default `group` is still "Other1" and now you can **create/edit** your own group name (*only for version study >= 9.2*).
 
-```{r st-storage}
+```{r st-storage/group}
 # creation
 createClusterST(area = "fr", 
                 cluster_name = "test_storage", 
@@ -82,7 +84,117 @@ editClusterST(area = "fr",
               cluster_name = "test_storage", 
               group = "my_own_group_Pondage")
 
+# read cluster properties
+tab <- readClusterSTDesc()
+rmarkdown::paged_table(tab)
+```
+### New properties
+
+you can create or edit new clusters with new properties (see doc `?createClusterST`). 
+
+```{r default values}
+# new properties (default values)
+rmarkdown::paged_table(as.data.frame(storage_values_default(), check.names = FALSE))
+```
+
+```{r creation/properties}
+# creation
+my_parameters <- storage_values_default()
+my_parameters$efficiencywithdrawal <- 0.5
+my_parameters$`penalize-variation-injection` <- TRUE
+my_parameters$`penalize-variation-withdrawal` <- TRUE
+
+createClusterST(area = "fr", 
+                cluster_name = "test_storage", 
+                group = "new_properties", 
+                storage_parameters = my_parameters, 
+                overwrite = TRUE)
+
+createClusterST(area = "it", 
+                cluster_name = "test_storage", 
+                group = "new_properties", 
+                storage_parameters = my_parameters,
+                overwrite = TRUE)
+
 # read cluster properties 
+tab <- readClusterSTDesc()
+rmarkdown::paged_table(tab)
+```
+
+```{r edit/properties}
+# edit properties of existing st-storage cluster
+my_parameters$efficiencywithdrawal <- 0.9
+my_parameters$`penalize-variation-injection` <- FALSE
+my_parameters$`penalize-variation-withdrawal` <- FALSE
+
+editClusterST(area = "fr", 
+              cluster_name = "test_storage",
+              storage_parameters = my_parameters)
+
+# read cluster properties 
+tab <- readClusterSTDesc()
+rmarkdown::paged_table(tab)
+```
+
+### New optional **time series**
+
+We have five new *.txt* files containing one series of dimension ${N=8760, P=1}$ :  
+
+  - cost-injection.txt  
+  - cost-withdrawal.txt 
+  - cost-level.txt  
+  - cost-variation-injection.txt  
+  - cost-variation-withdrawal.txt
+  
+
+```{r create/ts}
+# creation
+ratio_value <- matrix(0.7, 8760)
+  
+# default properties with new optional TS
+createClusterST(area = "fr", 
+                cluster_name = "good_ts_value", 
+                cost_injection = ratio_value, 
+                cost_withdrawal = ratio_value, 
+                cost_level = ratio_value, 
+                cost_variation_injection = ratio_value,
+                cost_variation_withdrawal = ratio_value)
+
+# read cluster TS values 
+tab <- readInputTS(st_storage = "all", 
+                   showProgress = FALSE)
+rmarkdown::paged_table(head(tab))
+```
+
+```{r edit/ts}
+# edit TS values of existing st-storage cluster
+new_ratio_value <- matrix(0.85, 8760)
+
+# edit everything or anyone you want 
+editClusterST(area = "fr",
+              cluster_name = "good_ts_value",
+              cost_injection = new_ratio_value, 
+              cost_withdrawal = new_ratio_value)
+
+# read cluster TS values 
+tab <- readInputTS(st_storage = "all", 
+                   showProgress = FALSE)
+rmarkdown::paged_table(head(tab))
+```
+
+### Remove clusters
+
+Nothing has changed to remove clusters.
+
+```{r remove}
+# read cluster names
+levels(readClusterSTDesc()$cluster)
+
+# remove a cluster
+removeClusterST(area = "fr", 
+                cluster_name = "good_ts_value")
+
+# read cluster 
 tab <- readClusterSTDesc()
 rmarkdown::paged_table(tab)
 ```
@@ -94,3 +206,8 @@ unlink(current_study_opts$studyPath,
 # clean global options
 options(antares = NULL)
 ```
+
+
+
+
+


### PR DESCRIPTION
New parameters and Time Series available for : 

- `createClusterST()`
- `editClusterST()`

- [x] `TODO` : Doc + add example to `editClusterST()`
- [x] Vignette


Reforge tests <9.2 : 
  - [x] `createClusterST()`
  - [x] `editClusterST()` 
  - [x] add new file test for `removeClusterST()`
- [x] Fix `prefix` code part when edit only TS (no properties).
- [x] Put lower case on `cluster_name` and fix to put lower case even `prefix` is not `TRUE`

