### PR TITLE
fix clearScenarioBuilder() in API mode 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,10 @@ NEW FEATURES (other) :
   - `updateAdequacySettings()` : Two parameters (*enable-first-step*, *set-to-null-ntc-between-physical-out-for-first-step*) are **deprecated** and removed. Parameters are forced to `NULL` with study >= v9.2.
     
 
+BUGFIXES :    
+
+* `clearScenarioBuilder()` in API mode, updates correctly with empty data (`{}`)
+
 ### DOC :  
 
 A new article exposing new features of Antares Simulator v9.2 is available [here](https://rte-antares-rpackage.github.io/antaresEditObject/dev/articles/Antares_new_features_v920.html)

--- a/R/scenarioBuilder.R
+++ b/R/scenarioBuilder.R
@@ -552,11 +552,23 @@ updateScenarioBuilder <- function(ldata,
 clearScenarioBuilder <- function(ruleset = "Default Ruleset",
                                  opts = antaresRead::simOptions()) {
   if (is_api_study(opts)) {
-    cmd <- api_command_generate(
+    # cmd <- api_command_generate(
+    #   action = "update_config",
+    #   target = paste0("settings/scenariobuilder/", ruleset),
+    #   data = list()
+    # )
+    
+    # api_command_generate() can't be used with API (non compatible with [])
+    cmd <- list(
       action = "update_config",
-      target = paste0("settings/scenariobuilder/", ruleset),
-      data = list()
+      args = list(
+        target = paste0("settings/scenariobuilder/", 
+                        ruleset),
+        data = NULL
+      )
     )
+    class(cmd) <- c(class(cmd), "antares.api.command")
+    
     api_command_register(cmd, opts = opts)
     `if`(
       should_command_be_executed(opts), 


### PR DESCRIPTION
- `api_command_generate()` is no longer used
- push empty data with `{}` insted of `[]`