### PR TITLE
Key return_value has been renamed to returnValue  for the endpoint v1/…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,11 @@ BUGFIXES :
 
 * `.st_mandatory_params()` property efficiencywithdrawal is not a ratio and can be greater than 1.
 * `createStudy()` Since Antares 9.2, property `initial-reservoir-levels` in `generaldata/other preferences` is not needed. This property must be removed.
-* `api_command_execute()` Since Antares Web 2.31.0, the endpoint v1/tasks/<task_id> sends a property returnValue instead of return_value 
+ 
 
+BREAKING CHANGES :
+
+* `api_command_execute()` Since Antares Web 2.31.0, the endpoint v1/tasks/<task_id> sends a property returnValue instead of return_value
 
 # antaresEditObject 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ BUGFIXES :
 
 * `.st_mandatory_params()` property efficiencywithdrawal is not a ratio and can be greater than 1.
 * `createStudy()` Since Antares 9.2, property `initial-reservoir-levels` in `generaldata/other preferences` is not needed. This property must be removed.
+* `api_command_execute()` Since Antares Web 2.31.0, the endpoint v1/tasks/<task_id> sends a property returnValue instead of return_value 
 
 
 # antaresEditObject 1.0.0

--- a/R/API-utils.R
+++ b/R/API-utils.R
@@ -225,7 +225,7 @@ api_command_execute <- function(command, opts, text_alert = "{msg_api}") {
     # test if task is terminated with success
     result_task_id_log <- result_task_id$result
     status <- isTRUE(result_task_id_log$success)
-    details_command <- jsonlite::fromJSON(result_task_id_log$return_value, 
+    details_command <- jsonlite::fromJSON(result_task_id_log$returnValue, 
                                           simplifyVector = FALSE)
     
     if(status){


### PR DESCRIPTION
Key return_value has been renamed to returnValue  for the endpoint v1/tasks/<task_id>