### PR TITLE
Behaviour of createClusterST() with overwrite set to TRUE 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,8 @@ BUGFIXES :
 
 * `.st_mandatory_params()` property efficiencywithdrawal is not a ratio and can be greater than 1.
 * `createStudy()` Since Antares 9.2, property `initial-reservoir-levels` in `generaldata/other preferences` is not needed. This property must be removed.
- 
+* `createClusterST()` Ensure that if a storage is created with overwrite set to TRUE, the storage is overwritten 
+
 
 BREAKING CHANGES :
 

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -494,13 +494,14 @@ createClusterST <- function(area,
   previous_params <- readIniFile(file = path_clusters_ini)
   
   ## check cluster already exists ----
-  if (cluster_name %in% tolower(names(previous_params)) 
-      & !overwrite)
-    stop(paste(cluster_name, "already exist"))
+  cluster_exists <- cluster_name %in% tolower(names(previous_params))
+  if (cluster_exists & !overwrite) {
+    stop(paste(cluster_name, "already exists"))
+  }
   
   ## overwrite ----
   if (overwrite) {
-    if(cluster_name %in% tolower(names(previous_params))){
+    if (cluster_exists) {
       ind_cluster <- which(tolower(names(previous_params)) %in% 
                              cluster_name)[1]
       previous_params[[ind_cluster]] <- params_cluster

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -499,7 +499,7 @@ createClusterST <- function(area,
     stop(paste(cluster_name, "already exist"))
   
   ## overwrite ----
-  if(overwrite){
+  if (overwrite) {
     if(cluster_name %in% tolower(names(previous_params))){
       ind_cluster <- which(tolower(names(previous_params)) %in% 
                              cluster_name)[1]
@@ -558,8 +558,7 @@ createClusterST <- function(area,
     .add_storage_constraint(area = area, 
                             cluster_name = cluster_name, 
                             constraints_properties = constraints_properties, 
-                            constraints_ts = constraints_ts, 
-                            overwrite = overwrite, 
+                            constraints_ts = constraints_ts,  
                             opts = opts)
   
   # Update simulation options object
@@ -731,74 +730,37 @@ storage_values_default <- function(opts = simOptions()) {
                                     cluster_name, 
                                     constraints_properties, 
                                     constraints_ts, 
-                                    overwrite,
                                     opts){
   # constraints/<area id>/cluster/additional-constraints.ini
   
-  # create dir 
-  dir_path <- file.path(opts$inputPath, 
+  dir_path <- file.path(opts[["inputPath"]], 
                         "st-storage", 
                         "constraints", 
                         area, 
                         cluster_name)
+                      
   dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
   
   ## write properties ----
   
   # TODO check mandatory list params
   
-  # read previous content of ini (if exists)
-  path_contraint_ini <- file.path(dir_path, 
-                                  "additional-constraints.ini")
-  
-  if(file.exists(path_contraint_ini)){
-    previous_params <- readIniFile(file = path_contraint_ini)
-    
-    constraints_names <- names(constraints_properties)
-    
-    ## check constraint(s) already exist(s) ----
-    if (any(
-      constraints_names %in% 
-      tolower(names(previous_params)) & 
-      !overwrite))
-      stop(paste(constraints_names, " already exist "), 
-           call. = FALSE)
-    
-    ## overwrite prop ----
-    if(overwrite){
-      if(any(
-        constraints_names %in% tolower(names(previous_params))
-      )){
-        # insert/overwrite
-        ind_cluster <- which(tolower(names(previous_params)) %in% 
-                               constraints_names)
-        previous_params[ind_cluster] <- constraints_properties
-        constraints_properties <- previous_params
-        # names(previous_params)[ind_cluster] <- constraints_names
-      }else
-        constraints_properties <- append(previous_params, constraints_properties) 
-    }else
-      constraints_properties <- append(previous_params, constraints_properties)
-  }
   # write properties (all properties are overwritten)
   writeIni(
     listData = constraints_properties,
-    pathIni = path_contraint_ini,
+    pathIni = file.path(dir_path, "additional-constraints.ini"),
     overwrite = TRUE
   )
   
   ## write ts values ----
-  # check if ts already exist
-  if(!is.null(constraints_ts)){
-    ts_name <- paste0("rhs_", names(constraints_ts), ".txt")
-    path_ts_files <- file.path(dir_path, 
-                               ts_name)
-    
-    if(any(file.exists(path_ts_files))){
-      if(!overwrite)
-        stop(paste(constraints_names, " already exist "), 
-             call. = FALSE)
-    }
+  # User can create a storage with a constraint cstr1 and cstr2.
+  # Then he can create the same storage with the parameter overwrite set to TRUE with a constraint cstr1 and cstr3 .
+  # Ensure that only constraints having an entry in additional_constraints.ini have a time series.
+  rhs_files <- list.files(dir_path, pattern = "rhs_.*\\.txt", full.names = TRUE)
+  if (length(rhs_files) > 0) {
+    sapply(rhs_files, FUN = file.remove)
+  }
+  if (!is.null(constraints_ts)) {
     lapply(names(constraints_ts), 
            function(x){
              fwrite(

--- a/R/createClusterST.R
+++ b/R/createClusterST.R
@@ -755,8 +755,8 @@ storage_values_default <- function(opts = simOptions()) {
   
   ## write ts values ----
   # User can create a storage with a constraint cstr1 and cstr2.
-  # Then he can create the same storage with the parameter overwrite set to TRUE with a constraint cstr1 and cstr3 .
-  # Ensure that only constraints having an entry in additional_constraints.ini have a time series.
+  # Then he can create the same storage with the parameter overwrite set to TRUE with constraints cstr1 and cstr3.
+  # Ensure that only constraints having an entry in additional_constraints.ini have an associated time series.
   rhs_files <- list.files(dir_path, pattern = "rhs_.*\\.txt", full.names = TRUE)
   if (length(rhs_files) > 0) {
     sapply(rhs_files, FUN = file.remove)

--- a/tests/testthat/test-createClusterST.R
+++ b/tests/testthat/test-createClusterST.R
@@ -754,6 +754,123 @@ test_that("Add new binding constraint properties", {
     )
   })
   
+  test_that("Argument overwrite set to TRUE should remove/clear the previous data", {
+    cluster_name <- "cluster_to_overwrite"
+    good_ts <- matrix(0.7, 8760)
+    
+    # First run 
+    cstr1 <- "netting-2"
+    cstr2 <- "withdrawal-2"
+    
+    # Second run 
+    cstr3 <- "new_netting-2"
+    cstr4 <- "new_withdrawal-2"
+    cstr5 <- "new_netting-2"
+    
+    constraints_properties <- list(
+      "withdrawal-2" = list(
+        variable = "withdrawal",
+        operator = "equal",
+        hours = c("[1,3,5]", 
+                  "[120,121,122,123,124,125,126,127,128]")
+      ),
+      "netting-2" = list(
+        variable = "netting",
+        operator = "less",
+        hours = c("[1, 168]")
+      )
+    )
+    
+    constraints_ts <- list(
+        "withdrawal-2" = good_ts,
+        "netting-2" = good_ts
+    )
+    
+    # First run 
+    createClusterST(area = area_test_clust,
+                    cluster_name = cluster_name,
+                    group = "v1g",
+                    storage_parameters = storage_values_default(),
+                    add_prefix = TRUE,
+                    constraints_properties = constraints_properties,
+                    constraints_ts = constraints_ts,                  
+                    overwrite = TRUE,
+                    opts = simOptions()
+    )
+    
+    opts <- simOptions()    
+    cstr_path <- file.path(opts[["inputPath"]], 
+                           "st-storage", 
+                           "constraints", 
+                           area_test_clust, 
+                           paste0(area_test_clust,"_",cluster_name)
+                           )
+    
+    file_ts_cstr1 <- file.path(cstr_path, paste0("rhs_",cstr1,".txt"))
+    file_ts_cstr2 <- file.path(cstr_path, paste0("rhs_",cstr2,".txt"))
+    
+    expect_true(file.exists(file_ts_cstr1))
+    expect_true(file.exists(file_ts_cstr2))
+    
+    cstr_params <- readIniFile(file = file.path(cstr_path, "additional-constraints.ini"))
+    expect_equal(length(cstr_params), 2)
+    expect_true(all(c(cstr1, cstr2) %in% names(cstr_params)))
+  
+    # overwrite the cluster
+    constraints_properties_new <- list(
+      "new_withdrawal-2"=list(
+        variable = "withdrawal",
+        operator = "equal",
+        hours = c("[1,3,5]", 
+                  "[120,121,122,123,124,125,126,127,128]")
+      ),
+      "new_netting-2"=list(
+        variable = "netting",
+        operator = "less",
+        hours = c("[1, 168]")
+      ),
+      "new_netting-3"=list(
+        variable = "netting",
+        operator = "equal",
+        hours = c("[1, 168]")
+      )
+    )
+  
+    constraints_ts_new <- list(
+        "new_withdrawal-2" = good_ts,
+        "new_netting-2" = good_ts,
+        "new_netting-3" = good_ts
+    )
+    
+    # Second run with overwrite set to TRUE
+    createClusterST(area = area_test_clust,
+                    cluster_name = cluster_name,
+                    group = "v1g",
+                    storage_parameters = storage_values_default(),
+                    add_prefix = TRUE,
+                    constraints_properties = constraints_properties_new,
+                    constraints_ts = constraints_ts_new,                 
+                    overwrite = TRUE,
+                    opts = simOptions()
+    )
+    
+    file_ts_cstr3 <- file.path(cstr_path, paste0("rhs_",cstr3,".txt"))
+    file_ts_cstr4 <- file.path(cstr_path, paste0("rhs_",cstr4,".txt"))
+    file_ts_cstr5 <- file.path(cstr_path, paste0("rhs_",cstr5,".txt"))
+    
+    # Files file_ts_cstr1 and file_ts_cstr2 should be removed
+    expect_false(file.exists(file_ts_cstr1))
+    expect_false(file.exists(file_ts_cstr2))
+    
+    # Only files in constraints_properties_new should exist
+    expect_true(file.exists(file_ts_cstr3))
+    expect_true(file.exists(file_ts_cstr4))
+    expect_true(file.exists(file_ts_cstr5))
+    
+    cstr_params <- readIniFile(file = file.path(cstr_path, "additional-constraints.ini"))
+    expect_equal(length(cstr_params), 3)
+    expect_true(all(c(cstr3, cstr4, cstr5) %in% names(cstr_params)))
+  })
 })
 
 


### PR DESCRIPTION
- Remove argument overwrite in .add_storage_constraint()
- Clean the directory constraints/<area>/<storage> and the content of the file additional-constraints.ini in each case (overwrite TRUE or FALSE)